### PR TITLE
Add annotations.csv

### DIFF
--- a/scripts/input/owid/annotations.csv
+++ b/scripts/input/owid/annotations.csv
@@ -1,0 +1,12 @@
+location,day,cases_annotations,deaths_annotations
+Spain,2020-04-19,methodology change,
+Spain,2020-04-25,methodology change,methodology change
+Ecuador,2020-05-08,methodology change,
+United Kingdom,2020-05-20,methodology change,
+France,2020-06-02,methodology change,
+India,2020-06-17,,earlier deaths added
+Chile,2020-06-18,earlier cases added,
+Italy,2020-06-25,,methodology change
+United States,2020-06-26,,probable/earlier deaths added
+United States,2020-07-01,,probable/earlier deaths added
+European Union,,Some EU countries changed methodology. See country-by-country series.,Some EU countries changed methodology. See country-by-country series.

--- a/scripts/input/owid/annotations.csv
+++ b/scripts/input/owid/annotations.csv
@@ -1,4 +1,4 @@
-location,day,cases_annotations,deaths_annotations
+location,date,cases_annotations,deaths_annotations
 Spain,2020-04-19,methodology change,
 Spain,2020-04-25,methodology change,methodology change
 Ecuador,2020-05-08,methodology change,


### PR DESCRIPTION
Do we already have cases and deaths annotations in this repo? If not this adds it.

I can hook up Grapher to import entity annotations from this. I added a day column so when we deploy the front end for specific day annotations in Grapher then we are already set for it.

@edomt would this be the correct place to put this file?
@HannahRitchie  would this be easier to update than the current status quo? Anything else we can do?