### PR TITLE
remove duplicate country

### DIFF
--- a/scripts/input/iso/iso3166_1_alpha_3_codes.csv
+++ b/scripts/input/iso/iso3166_1_alpha_3_codes.csv
@@ -128,7 +128,6 @@ KNA,Saint Kitts and Nevis
 KOR,Republic of Korea
 KOR,South Korea
 KWT,Kuwait
-LAO,Lao People's Democratic Republic
 LAO,Laos
 LBN,Lebanon
 LBR,Liberia

--- a/scripts/input/iso/iso3166_1_alpha_3_codes.csv
+++ b/scripts/input/iso/iso3166_1_alpha_3_codes.csv
@@ -34,7 +34,6 @@ BMU,Bermuda
 BOL,Bolivia
 BRA,Brazil
 BRB,Barbados
-BRN,Brunei Darussalam
 BRN,Brunei
 BTN,Bhutan
 BVT,Bouvet Island
@@ -75,10 +74,8 @@ EST,Estonia
 ETH,Ethiopia
 FIN,Finland
 FJI,Fiji
-FLK,Falkland Islands (Malvinas)
 FLK,Falkland Islands
 FRA,France
-FRO,Faroe Islands
 FRO,Faeroe Islands
 FSM,Federated States of Micronesia
 GAB,Gabon
@@ -125,13 +122,11 @@ KGZ,Kyrgyzstan
 KHM,Cambodia
 KIR,Kiribati
 KNA,Saint Kitts and Nevis
-KOR,Republic of Korea
 KOR,South Korea
 KWT,Kuwait
 LAO,Laos
 LBN,Lebanon
 LBR,Liberia
-LBY,Libyan Arab Jamahiriya
 LBY,Libya
 LCA,Saint Lucia
 LIE,Liechtenstein
@@ -189,13 +184,11 @@ PRI,Puerto Rico
 PRK,Democratic People's Republic of Korea
 PRT,Portugal
 PRY,Paraguay
-PSE,Palestinian Territory
 PSE,Palestine
 PYF,French Polynesia
 QAT,Qatar
 REU,Réunion
 ROU,Romania
-RUS,Russian Federation
 RUS,Russia
 RWA,Rwanda
 SAU,Saudi Arabia
@@ -221,7 +214,6 @@ SWE,Sweden
 SWZ,Eswatini
 SXM,Sint Maarten (Dutch part)
 SYC,Seychelles
-SYR,Syrian Arab Republic
 SYR,Syria
 TCA,Turks and Caicos Islands
 TCD,Chad
@@ -230,7 +222,6 @@ THA,Thailand
 TJK,Tajikistan
 TKL,Tokelau
 TKM,Turkmenistan
-TLS,Timor-Leste
 TLS,Timor
 TON,Tonga
 TTO,Trinidad and Tobago
@@ -250,7 +241,6 @@ VCT,Saint Vincent and the Grenadines
 VEN,Venezuela
 VGB,British Virgin Islands
 VIR,United States Virgin Islands
-VNM,Viet Nam
 VNM,Vietnam
 VUT,Vanuatu
 WLF,Wallis and Futuna


### PR DESCRIPTION
Lao People's Democratic Republic is another name (the official one) to indicate Laos.