### PR TITLE
Automate vax for United Arab Emirates

### DIFF
--- a/scripts/scripts/vaccinations/automations/automation_state.csv
+++ b/scripts/scripts/vaccinations/automations/automation_state.csv
@@ -15,6 +15,7 @@ Romania,TRUE
 Scotland,TRUE
 Slovenia,TRUE
 Spain,TRUE
+United Arab Emirates,TRUE
 United Kingdom,TRUE
 United States,TRUE
 Wales,TRUE
@@ -44,4 +45,3 @@ Portugal,FALSE
 Russia,FALSE
 Saudi Arabia,FALSE
 Slovakia,FALSE
-United Arab Emirates,FALSE

--- a/scripts/scripts/vaccinations/automations/incremental/united_arab_emirates.py
+++ b/scripts/scripts/vaccinations/automations/incremental/united_arab_emirates.py
@@ -1,0 +1,25 @@
+import pytz
+import datetime
+import requests
+from bs4 import BeautifulSoup
+import vaxutils
+
+def main():
+    url = "http://covid19.ncema.gov.ae/en"
+    soup = BeautifulSoup(requests.get(url).content, "html.parser")
+
+    count = soup.find(class_="doses").find(class_="counter").text
+    count = vaxutils.clean_count(count)
+    date = str(datetime.datetime.now(pytz.timezone('Asia/Dubai')).date())
+
+    vaxutils.increment(
+        location="United Arab Emirates",
+        total_vaccinations=count,
+        date=date,
+        source_url=url,
+        vaccine="Sinopharm"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/scripts/vaccinations/automations/output/United Arab Emirates.csv
+++ b/scripts/scripts/vaccinations/automations/output/United Arab Emirates.csv
@@ -1,0 +1,2 @@
+location,date,vaccine,total_vaccinations,source_url
+United Arab Emirates,2021-01-05,Sinopharm,826301,https://twitter.com/NCEMAUAE/status/1346504959441952768


### PR DESCRIPTION
Added incremental automation for the United Arab Emirates. Used this reference: https://covid19.ncema.gov.ae/en.

Similarly to the [automation for Spain](https://github.com/owid/covid-19-data/blob/master/scripts/scripts/vaccinations/automations/incremental/spain.py) it uses the execution date as the date of the data.

**Minor doubt**: Do we use the date as in UTC, country local time, etc.? For this automation, I have used country local time (note the use of `pytz`) but, for instance, in the automation for Spain it seems that you use the date from the place the script is executed (`datetime.date.now()`)