### PR TITLE
Update United Kingdom.csv

### DIFF
--- a/public/data/vaccinations/country_data/United Kingdom.csv
+++ b/public/data/vaccinations/country_data/United Kingdom.csv
@@ -1,3 +1,4 @@
 location,date,vaccine,total_vaccinations,source_url
 United Kingdom,2020-12-20,Pfizer/BioNTech,641116,https://coronavirus.data.gov.uk/
 United Kingdom,2020-12-27,Pfizer/BioNTech,944539,https://coronavirus.data.gov.uk/
+United Kingdom,2021-01-03,"Oxford/AstraZeneca, Pfizer/BioNTech",1296432,https://coronavirus.data.gov.uk/


### PR DESCRIPTION
This is pulled from https://api.coronavirus.data.gov.uk/v2/data?areaType=overview&metric=cumPeopleReceivingFirstDose&metric=cumPeopleReceivingSecondDose&format=csv, which is actually in the automation in https://github.com/owid/covid-19-data/blob/master/scripts/scripts/vaccinations/automations/batch/united_kingdom.py, but that automation doesn't appear to be running.