### PR TITLE
Ireland vaccinations csv: Numbers for 2021-01-14

### DIFF
--- a/public/data/vaccinations/country_data/Ireland.csv
+++ b/public/data/vaccinations/country_data/Ireland.csv
@@ -3,3 +3,4 @@ Ireland,2020-12-31,Pfizer/BioNTech,https://twitter.com/RobOHanrahan/status/13449
 Ireland,2021-01-04,Pfizer/BioNTech,https://www.thejournal.ie/covid-19-vaccine-rollout-in-nursing-homes-gets-under-way-this-week-5315501-Jan2021/,4000,4000,0
 Ireland,2021-01-07,Pfizer/BioNTech,https://twitter.com/newschambers/status/1347187910961999873,15314,15314,0
 Ireland,2021-01-10,Pfizer/BioNTech,https://twitter.com/DonnellyStephen/status/1349442669622263811,40000,40000,0
+Ireland,2021-01-14,Pfizer/BioNTech,https://www.rte.ie/news/coronavirus/2021/0114/1189739-vaccine-numbers/,77303,77303,0


### PR DESCRIPTION
As sourced here: https://www.rte.ie/news/coronavirus/2021/0114/1189739-vaccine-numbers/

Ireland's Health Service Executive has issued an update stating 77,303 vaccines have been administered to date (yesterday, according to article).