### PR TITLE
VACCINATIONS: Bulgaria started Moderna vaccine administration

### DIFF
--- a/scripts/scripts/vaccinations/automations/incremental/bulgaria.py
+++ b/scripts/scripts/vaccinations/automations/incremental/bulgaria.py
@@ -25,7 +25,7 @@ def main():
         total_vaccinations=count,
         date=date,
         source_url=url,
-        vaccine="Pfizer/BioNTech"
+        vaccine="Moderna, Pfizer/BioNTech"
     )
 
 


### PR DESCRIPTION
Bulgaria started administering the Moderna vaccine on the 14th January 2021 ([Reference](https://www.reuters.com/article/us-health-coronavirus-bulgaria-moderna/facing-criticism-over-slow-rollout-bulgaria-starts-moderna-vaccinations-idUSKBN29J14Y)).