### PR TITLE
VACCINATIONS: Spain started Moderna vaccine administration

### DIFF
--- a/scripts/scripts/vaccinations/automations/incremental/spain.py
+++ b/scripts/scripts/vaccinations/automations/incremental/spain.py
@@ -19,7 +19,7 @@ def main():
         total_vaccinations=count,
         date=date,
         source_url=url,
-        vaccine="Pfizer/BioNTech"
+        vaccine="Moderna, Pfizer/BioNTech"
     )
 
 


### PR DESCRIPTION
As reported today 15th January 2021, the autonomous community region of the Basque Country started the administration of the Moderna vaccine.

**References**
- [Basque Autonomous Community's public broadcast service](https://www.eitb.eus/es/noticias/sociedad/detalle/7771909/vacunacion-moderna-cav-15-enero-comienzan-vacunar-personal-sanitario/)
- [Basque Government](https://www.euskadi.eus/gobierno-vasco/-/noticia/2021/primeras-vacunas-covid-19-profesionales-osakidetza/)