### PR TITLE
Update Serbia.csv

### DIFF
--- a/public/data/vaccinations/country_data/Serbia.csv
+++ b/public/data/vaccinations/country_data/Serbia.csv
@@ -6,3 +6,4 @@ Serbia,2021-01-20,"Pfizer/BioNTech, Sinopharm, Sputnik V",http://tanjug.rs/full-
 Serbia,2021-01-21,"Pfizer/BioNTech, Sinopharm, Sputnik V",https://www.blic.rs/vesti/drustvo/saznajemo-u-srbiji-do-veceras-vakcinisano-ukupno-84832-osobe/rqk9z4m,84832,84832,0
 Serbia,2021-01-22,"Pfizer/BioNTech, Sinopharm, Sputnik V",https://www.srbija.gov.rs/vest/514113/vakcinacija-u-srbiji-krenula-veoma-dobro.php,119711,119711,0
 Serbia,2021-01-23,"Pfizer/BioNTech, Sinopharm, Sputnik V",https://www.telegraf.rs/vesti/srbija/3292522-u-srbiji-vakcinisano-163355-osoba-kol-centri-rade-punom-parom-vakcinu-dobilo-jos-8000-prosvetara,163355,163355,0
+Serbia,2021-01-25,"Pfizer/BioNTech, Sinopharm, Sputnik V",https://www.danas.rs/drustvo/rts-do-sada-vakcinisan-256-521-gradjanin-protiv-korona-virusa-u-srbiji/


### PR DESCRIPTION
25.01.2021. Serbia, vaccinated 256.521 

https://www.danas.rs/drustvo/rts-do-sada-vakcinisan-256-521-gradjanin-protiv-korona-virusa-u-srbiji/