### PR TITLE
Update Serbia

### DIFF
--- a/public/data/vaccinations/locations.csv
+++ b/public/data/vaccinations/locations.csv
@@ -48,7 +48,7 @@ Romania,ROU,Pfizer/BioNTech,2021-01-26,Government of Romania,https://vaccinare-c
 Russia,RUS,Sputnik V,2021-01-13,Russian Direct Investment Fund,https://twitter.com/redouad/status/1350030539944820736
 Saudi Arabia,SAU,Pfizer/BioNTech,2021-01-17,Saudi Health Council,https://coronamap.sa/
 Scotland,,"Oxford/AstraZeneca, Pfizer/BioNTech",2021-01-25,Government of the United Kingdom,https://coronavirus.data.gov.uk/details/healthcare
-Serbia,SRB,"Pfizer/BioNTech, Sinopharm, Sputnik V",2021-01-26,Government of Serbia,https://www.rts.rs/page/stories/sr/%D0%9A%D0%BE%D1%80%D0%BE%D0%BD%D0%B0%D0%B2%D0%B8%D1%80%D1%83%D1%81/story/3134/koronavirus-u-srbiji/4234704/koronavirus-srbija-podaci-26.-januar.html
+Serbia,SRB,"Pfizer/BioNTech, Sinopharm, Sputnik V",2021-01-26,Government of Serbia,https://www.aa.com.tr/ba/balkan/vu%C4%8Di%C4%87-u-srbiji-protiv-koronavirusa-vakcinisano-skoro-320000-ljudi/2123908
 Seychelles,SYC,Sinopharm,2021-01-25,Extended Programme for Immunisation,https://www.facebook.com/mohseychellesofficial/photos/1640337966167328
 Singapore,SGP,Pfizer/BioNTech,2021-01-22,Ministry of Health,https://www.moh.gov.sg/news-highlights/details/tightening-safe-management-measures-and-update-on-vaccination-plans
 Slovakia,SVK,Pfizer/BioNTech,2021-01-25,Ministry of Health,https://github.com/Institut-Zdravotnych-Analyz/covid19-data


### PR DESCRIPTION
Serbia 26.01.2021. vaccinated 319.504

https://www.aa.com.tr/ba/balkan/vu%C4%8Di%C4%87-u-srbiji-protiv-koronavirusa-vakcinisano-skoro-320000-ljudi/2123908