### PR TITLE
serbia update

### DIFF
--- a/public/data/vaccinations/locations.csv
+++ b/public/data/vaccinations/locations.csv
@@ -49,7 +49,7 @@ Romania,ROU,Pfizer/BioNTech,2021-01-28,Government of Romania,https://vaccinare-c
 Russia,RUS,Sputnik V,2021-01-13,Russian Direct Investment Fund,https://twitter.com/redouad/status/1350030539944820736
 Saudi Arabia,SAU,Pfizer/BioNTech,2021-01-17,Saudi Health Council,https://coronamap.sa
 Scotland,,"Oxford/AstraZeneca, Pfizer/BioNTech",2021-01-26,Government of the United Kingdom,https://coronavirus.data.gov.uk/details/healthcare
-Serbia,SRB,"Pfizer/BioNTech, Sinopharm, Sputnik V",2021-01-27,Government of Serbia,https://www.b92.net/eng/news/society.php?yyyy=2021&mm=01&dd=27&nav_id=110282
+Serbia,SRB,"Pfizer/BioNTech, Sinopharm, Sputnik V",2021-01-27,Government of Serbia,http://www.politika.rs/sr/clanak/471786/U-Srbiji-vakcinisano-vise-od-400-hiljada-gradana
 Seychelles,SYC,"Covishield, Sinopharm",2021-01-27,Extended Programme for Immunisation,https://www.facebook.com/mohseychellesofficial/photos/1642132289321229
 Singapore,SGP,Pfizer/BioNTech,2021-01-28,Ministry of Health,https://www.moh.gov.sg/news-highlights/details/update-on-covid-19-vaccination-programme
 Slovakia,SVK,Pfizer/BioNTech,2021-01-27,Ministry of Health,https://covid-19.nczisk.sk


### PR DESCRIPTION
Serbia: 401.556 vaccinated (28.01.2021.)

http://www.politika.rs/sr/clanak/471786/U-Srbiji-vakcinisano-vise-od-400-hiljada-gradana