### PR TITLE
Update vaccines in Brazil (Covishield)

### DIFF
--- a/public/data/vaccinations/locations.csv
+++ b/public/data/vaccinations/locations.csv
@@ -4,7 +4,7 @@ Austria,AUT,Pfizer/BioNTech,2021-01-29,Ministry of Health,https://www.data.gv.at
 Bahrain,BHR,"Pfizer/BioNTech, Sinopharm",2021-01-28,Ministry of Health,https://twitter.com/MOH_Bahrain/status/1354897121137319936
 Belgium,BEL,"Moderna, Pfizer/BioNTech",2021-01-28,Sciensano,https://datastudio.google.com/embed/u/0/reporting/c14a5cfc-cab7-4812-848c-0369173148ab/page/hOMwB
 Bermuda,BMU,Pfizer/BioNTech,2021-01-23,Ministry of Health,https://www.gov.bm/articles/covid-19-update-minister-health-remarks-26-january-2021
-Brazil,BRA,Sinovac,2021-01-29,Regional governments via Coronavirus Brasil,https://coronavirusbra1.github.io/
+Brazil,BRA,"Sinovac, Covishield",2021-01-29,Regional governments via Coronavirus Brasil,https://coronavirusbra1.github.io/
 Bulgaria,BGR,"Moderna, Pfizer/BioNTech",2021-01-28,Ministry of Health,https://coronavirus.bg/bg/statistika
 Canada,CAN,"Moderna, Pfizer/BioNTech",2021-01-29,Government of Canada,https://health-infobase.canada.ca/covid-19/vaccination-coverage/
 Chile,CHL,Pfizer/BioNTech,2021-01-28,Department of Statistics and Health Information,https://informesdeis.minsal.cl/SASVisualAnalytics/?reportUri=%2Freports%2Freports%2F1a8cc7ff-7df0-474f-a147-929ee45d1900&sectionIndex=0&sso_guest=true&reportViewOnly=true&reportContextBar=false&sas-welcome=false


### PR DESCRIPTION
The vaccination with Covishield have already started in brazilian cities.

[https://www.cnnbrasil.com.br/saude/2021/01/23/fiocruz-aplica-primeiras-doses-da-vacina-de-oxford-no-brasil](https://www.cnnbrasil.com.br/saude/2021/01/23/fiocruz-aplica-primeiras-doses-da-vacina-de-oxford-no-brasil)