### PR TITLE
serbia update

### DIFF
--- a/public/data/vaccinations/locations.csv
+++ b/public/data/vaccinations/locations.csv
@@ -49,7 +49,7 @@ Romania,ROU,Pfizer/BioNTech,2021-01-29,Government of Romania,https://vaccinare-c
 Russia,RUS,Sputnik V,2021-01-13,Russian Direct Investment Fund,https://twitter.com/redouad/status/1350030539944820736
 Saudi Arabia,SAU,Pfizer/BioNTech,2021-01-17,Saudi Health Council,https://coronamap.sa
 Scotland,,"Oxford/AstraZeneca, Pfizer/BioNTech",2021-01-28,Government of the United Kingdom,https://coronavirus.data.gov.uk/details/healthcare
-Serbia,SRB,"Pfizer/BioNTech, Sinopharm, Sputnik V",2021-01-29,Government of Serbia,https://www.b92.net/info/vesti/index.php?yyyy=2021&mm=01&dd=29&nav_category=12&nav_id=1802807
+Serbia,SRB,"Pfizer/BioNTech, Sinopharm, Sputnik V",2021-01-29,Government of Serbia,https://www.021.rs/story/Info/Srbija/264881/U-Srbiji-do-sada-vakcinisano-430759-gradjana.html
 Seychelles,SYC,"Covishield, Sinopharm",2021-01-28,Extended Programme for Immunisation,https://www.facebook.com/mohseychellesofficial/photos/1643135392554252
 Singapore,SGP,Pfizer/BioNTech,2021-01-28,Ministry of Health,https://www.moh.gov.sg/news-highlights/details/update-on-covid-19-vaccination-programme
 Slovakia,SVK,Pfizer/BioNTech,2021-01-28,Ministry of Health,https://covid-19.nczisk.sk


### PR DESCRIPTION
430.759 vaccinated at the end of the day (29.01.2021.)
https://www.021.rs/story/Info/Srbija/264881/U-Srbiji-do-sada-vakcinisano-430759-gradjana.html