### PR TITLE
Serbia update

### DIFF
--- a/public/data/vaccinations/locations.csv
+++ b/public/data/vaccinations/locations.csv
@@ -51,7 +51,7 @@ Romania,ROU,Pfizer/BioNTech,2021-02-01,Government of Romania,https://vaccinare-c
 Russia,RUS,Sputnik V,2021-01-13,Russian Direct Investment Fund,https://twitter.com/redouad/status/1350030539944820736
 Saudi Arabia,SAU,Pfizer/BioNTech,2021-02-01,Saudi Health Council,https://coronamap.sa
 Scotland,,"Oxford/AstraZeneca, Pfizer/BioNTech",2021-01-31,Government of the United Kingdom,https://coronavirus.data.gov.uk/details/healthcare
-Serbia,SRB,"Pfizer/BioNTech, Sinopharm, Sputnik V",2021-01-30,Government of Serbia,https://www.srbija.gov.rs/vest/en/166989/serbia-second-in-europe-by-number-of-covid-immunisations-per-million-people.php
+Serbia,SRB,"Pfizer/BioNTech, Sinopharm, Sputnik V",2021-01-30,Government of Serbia,https://www.rts.rs/page/stories/sr/%D0%9A%D0%BE%D1%80%D0%BE%D0%BD%D0%B0%D0%B2%D0%B8%D1%80%D1%83%D1%81/story/3134/koronavirus-u-srbiji/4242974/korona-srbija-podaci-zarazeni.html
 Seychelles,SYC,"Oxford/AstraZeneca, Sinopharm",2021-01-29,Extended Programme for Immunisation,http://www.health.gov.sc/wp-content/uploads/COVID-19-VACCINATION-UPTAKE-REPORT_29TH-January-2021.pdf
 Singapore,SGP,Pfizer/BioNTech,2021-01-31,Ministry of Health,https://www.moh.gov.sg/news-highlights/details/the-progress-of-our-covid-19-vaccination-programme-and-adverse-events
 Slovakia,SVK,Pfizer/BioNTech,2021-01-31,Ministry of Health,https://covid-19.nczisk.sk


### PR DESCRIPTION
Serbia: 
495.964 vaccinated 
https://www.kurir.rs/vesti/drustvo/3617183/u-srbiji-vakcinisano-skoro-pola-miliona-gradjana-i-dalje-u-regionu-ubedljivo-prvi-drugi-u-evropi
