### PR TITLE
Update Switzerland vaccination data pull

### DIFF
--- a/scripts/scripts/vaccinations/automations/incremental/switzerland.py
+++ b/scripts/scripts/vaccinations/automations/incremental/switzerland.py
@@ -7,7 +7,7 @@ import vaxutils
 
 def main():
 
-    url = "https://www.covid19.admin.ch/en/epidemiologic/vacc-doses"
+    url = "https://www.covid19.admin.ch/en/epidemiologic/vacc-doses?detGeo=CH"
     soup = BeautifulSoup(requests.get(url).content, "html.parser")
 
     table = soup.find(class_="geo-unit-vacc-doses-data__table")
@@ -25,7 +25,7 @@ def main():
         total_vaccinations=total_vaccinations,
         date=date,
         source_url=url,
-        vaccine="Moderna, Pfizer/BioNTech"
+        vaccine="Moderna, Pfizer/BioNTech, Oxford/AstraZeneca"
     )
 
 

--- a/scripts/scripts/vaccinations/automations/incremental/switzerland.py
+++ b/scripts/scripts/vaccinations/automations/incremental/switzerland.py
@@ -25,7 +25,7 @@ def main():
         total_vaccinations=total_vaccinations,
         date=date,
         source_url=url,
-        vaccine="Moderna, Pfizer/BioNTech, Oxford/AstraZeneca"
+        vaccine="Moderna, Pfizer/BioNTech"
     )
 
 


### PR DESCRIPTION
The current source url(https://www.covid19.admin.ch/en/epidemiologic/vacc-doses)
pulls data for both Switzerland and Liechtenstein. Updating source url to get only Switzerland data (https://www.covid19.admin.ch/en/epidemiologic/vacc-doses?detGeo=CH) and also include Oxford/AstraZeneca vaccine. Could you please merge file with main branch.

Source : https://www.covid19.admin.ch/en/epidemiologic/vacc-doses?detGeo=CH
File : switzerland.py