### PR TITLE
Serbia update

### DIFF
--- a/public/data/vaccinations/locations.csv
+++ b/public/data/vaccinations/locations.csv
@@ -65,7 +65,7 @@ Russia,RUS,Sputnik V,2021-01-13,Russian Direct Investment Fund,https://twitter.c
 Saint Helena,SHN,Oxford/AstraZeneca,2021-02-03,Government of Saint Helena,https://www.sainthelena.gov.sh/2021/news/covid-19-vaccination-programme-update/
 Saudi Arabia,SAU,Pfizer/BioNTech,2021-02-01,Saudi Health Council,https://coronamap.sa
 Scotland,,"Oxford/AstraZeneca, Pfizer/BioNTech",2021-02-05,Government of the United Kingdom,https://coronavirus.data.gov.uk/details/healthcare
-Serbia,SRB,"Pfizer/BioNTech, Sinopharm, Sputnik V",2021-02-05,Government of Serbia,https://nova.rs/vesti/drustvo/srbija-2-u-evropi-po-broju-vakcinacija-na-milion-stanovnika/
+Serbia,SRB,"Pfizer/BioNTech, Sinopharm, Sputnik V",2021-02-05,Government of Serbia,https://www.danas.rs/drustvo/vakcinu-protiv-korona-virusa-u-srbiji-do-sada-primilo-544-209-osoba/
 Seychelles,SYC,"Oxford/AstraZeneca, Sinopharm",2021-02-03,Extended Programme for Immunisation,https://www.facebook.com/mohseychellesofficial/photos/1648953545305770
 Singapore,SGP,Pfizer/BioNTech,2021-02-02,Ministry of Health,https://www.moh.gov.sg/news-highlights/details/second-covid-19-vaccine-authorised-for-use-in-singapore
 Slovakia,SVK,Pfizer/BioNTech,2021-02-06,Ministry of Health,https://covid-19.nczisk.sk


### PR DESCRIPTION
544.209 vaccinated in Serbia 
https://www.danas.rs/drustvo/vakcinu-protiv-korona-virusa-u-srbiji-do-sada-primilo-544-209-osoba/