### PR TITLE
Update Jersey vaccine deployment

### DIFF
--- a/scripts/scripts/vaccinations/automations/incremental/jersey.py
+++ b/scripts/scripts/vaccinations/automations/incremental/jersey.py
@@ -27,7 +27,7 @@ def main():
         people_fully_vaccinated=people_fully_vaccinated,
         date=date,
         source_url=url,
-        vaccine="Pfizer/BioNTech"
+        vaccine="Oxford/AstraZeneca, Pfizer/BioNTech"
     )
 
 


### PR DESCRIPTION
Updated Jersey vaccine list. Could you please merge the request.
Source:
https://www.gov.je/Health/Coronavirus/Vaccine/Pages/COVID19VaccineInformation.aspx