### PR TITLE
Update Isle of Man vaccine deployment

### DIFF
--- a/scripts/scripts/vaccinations/automations/incremental/isle_of_man.py
+++ b/scripts/scripts/vaccinations/automations/incremental/isle_of_man.py
@@ -39,7 +39,7 @@ def main():
         people_fully_vaccinated=people_fully_vaccinated,
         date=date,
         source_url="https://covid19.gov.im/general-information/covid-19-vaccination-statistics/",
-        vaccine="Pfizer/BioNTech"
+        vaccine="Oxford/AstraZeneca, Pfizer/BioNTech"
     )
 
 


### PR DESCRIPTION
Updated Isle of Man vaccine list. Could you please merge the request.
Source:
https://covid19.gov.im/general-information/covid-19-vaccination-statistics/