### PR TITLE
Serbia update

### DIFF
--- a/public/data/vaccinations/locations.csv
+++ b/public/data/vaccinations/locations.csv
@@ -65,7 +65,7 @@ Russia,RUS,Sputnik V,2021-01-13,Russian Direct Investment Fund,https://twitter.c
 Saint Helena,SHN,Oxford/AstraZeneca,2021-02-03,Government of Saint Helena,https://www.sainthelena.gov.sh/2021/news/covid-19-vaccination-programme-update/
 Saudi Arabia,SAU,Pfizer/BioNTech,2021-02-07,Saudi Health Council,https://coronamap.sa
 Scotland,,"Oxford/AstraZeneca, Pfizer/BioNTech",2021-02-08,Government of the United Kingdom,https://coronavirus.data.gov.uk/details/healthcare
-Serbia,SRB,"Pfizer/BioNTech, Sinopharm/Beijing, Sputnik V",2021-02-07,Government of Serbia,https://www.danas.rs/drustvo/vakcinu-protiv-korona-virusa-u-srbiji-do-sada-primilo-544-209-osoba/
+Serbia,SRB,"Pfizer/BioNTech, Sinopharm/Beijing, Sputnik V",2021-02-07,Government of Serbia,https://www.alo.rs/vesti/drustvo/592-634-primilo-vakcinu-sve-veci-broj-revakcinisanih/383807/vest
 Seychelles,SYC,"Oxford/AstraZeneca, Sinopharm/Beijing",2021-02-08,Extended Programme for Immunisation,https://www.facebook.com/mohseychellesofficial/photos/1653550278179430
 Singapore,SGP,Pfizer/BioNTech,2021-02-02,Ministry of Health,https://www.moh.gov.sg/news-highlights/details/second-covid-19-vaccine-authorised-for-use-in-singapore
 Slovakia,SVK,Pfizer/BioNTech,2021-02-09,Ministry of Health,https://github.com/Institut-Zdravotnych-Analyz/covid19-data


### PR DESCRIPTION
592.634 vaccinated in Serbia (10.02.2021.)

https://www.alo.rs/vesti/drustvo/592-634-primilo-vakcinu-sve-veci-broj-revakcinisanih/383807/vest