### PR TITLE
Serbia update

### DIFF
--- a/public/data/vaccinations/locations.csv
+++ b/public/data/vaccinations/locations.csv
@@ -66,7 +66,7 @@ Russia,RUS,Sputnik V,2021-01-13,Russian Direct Investment Fund,https://twitter.c
 Saint Helena,SHN,Oxford/AstraZeneca,2021-02-03,Government of Saint Helena,https://www.sainthelena.gov.sh/2021/news/covid-19-vaccination-programme-update/
 Saudi Arabia,SAU,Pfizer/BioNTech,2021-02-07,Saudi Health Council,https://coronamap.sa
 Scotland,,"Oxford/AstraZeneca, Pfizer/BioNTech",2021-02-09,Government of the United Kingdom,https://coronavirus.data.gov.uk/details/healthcare
-Serbia,SRB,"Pfizer/BioNTech, Sinopharm/Beijing, Sputnik V",2021-02-10,Government of Serbia,https://www.alo.rs/vesti/drustvo/592-634-primilo-vakcinu-sve-veci-broj-revakcinisanih/383807/vest
+Serbia,SRB,"Pfizer/BioNTech, Sinopharm/Beijing, Sputnik V",2021-02-10,Government of Serbia,https://www.kurir.rs/amp/3622973/danas-tacno-2000-novozarazenih-najnoviji-korona-presek-u-srbiji-15-preminulih-raste-broj-pacijenata-na-respiratorima
 Seychelles,SYC,"Oxford/AstraZeneca, Sinopharm/Beijing",2021-02-09,Extended Programme for Immunisation,https://www.facebook.com/mohseychellesofficial/photos/1654367171431074
 Singapore,SGP,Pfizer/BioNTech,2021-02-10,Ministry of Health,https://www.pmo.gov.sg/Newsroom/Chinese-New-Year-Message-2021-by-PM-Lee-Hsien-Loong
 Slovakia,SVK,Pfizer/BioNTech,2021-02-09,Ministry of Health,https://github.com/Institut-Zdravotnych-Analyz/covid19-data


### PR DESCRIPTION
Fix number of vaccinated people in Serbia
Until today(3PM CET 11.02.2021.) 636.119 vaccinated 

83.262 fully vaccinated. 

https://www.kurir.rs/amp/3622973/danas-tacno-2000-novozarazenih-najnoviji-korona-presek-u-srbiji-15-preminulih-raste-broj-pacijenata-na-respiratorima