### PR TITLE
Serbia update

### DIFF
--- a/public/data/vaccinations/locations.csv
+++ b/public/data/vaccinations/locations.csv
@@ -70,7 +70,7 @@ Russia,RUS,Sputnik V,2021-02-10,Russian Direct Investment Fund,https://www.reute
 Saint Helena,SHN,Oxford/AstraZeneca,2021-02-03,Government of Saint Helena,https://www.sainthelena.gov.sh/2021/news/covid-19-vaccination-programme-update/
 Saudi Arabia,SAU,Pfizer/BioNTech,2021-02-11,Saudi Health Council,https://coronamap.sa
 Scotland,,"Oxford/AstraZeneca, Pfizer/BioNTech",2021-02-10,Government of the United Kingdom,https://coronavirus.data.gov.uk/details/healthcare
-Serbia,SRB,"Pfizer/BioNTech, Sinopharm/Beijing, Sputnik V",2021-02-11,Government of Serbia,https://www.kurir.rs/amp/3622973/danas-tacno-2000-novozarazenih-najnoviji-korona-presek-u-srbiji-15-preminulih-raste-broj-pacijenata-na-respiratorima
+Serbia,SRB,"Pfizer/BioNTech, Sinopharm/Beijing, Sputnik V",2021-02-11,Government of Serbia,https://www.srbija.gov.rs/vest/en/167733/considering-tightening-of-measures-due-to-deterioration-of-epidemiological-situation.php
 Seychelles,SYC,"Oxford/AstraZeneca, Sinopharm/Beijing",2021-02-10,Extended Programme for Immunisation,https://www.facebook.com/mohseychellesofficial/photos/1655404677993990
 Singapore,SGP,Pfizer/BioNTech,2021-02-10,Ministry of Health,https://www.pmo.gov.sg/Newsroom/Chinese-New-Year-Message-2021-by-PM-Lee-Hsien-Loong
 Slovakia,SVK,Pfizer/BioNTech,2021-02-11,Ministry of Health,https://covid-19.nczisk.sk


### PR DESCRIPTION
126,149 people have been revaccinated in Serbia so far, a total of 710,138 doses of the coronavirus vaccine have been given so far, and the total number of those who received only the first dose is 583,989.

https://www.srbija.gov.rs/vest/en/167733/considering-tightening-of-measures-due-to-deterioration-of-epidemiological-situation.php