### PR TITLE
Serbia update

### DIFF
--- a/public/data/vaccinations/locations.csv
+++ b/public/data/vaccinations/locations.csv
@@ -70,7 +70,7 @@ Russia,RUS,Sputnik V,2021-02-10,Russian Direct Investment Fund,https://www.reute
 Saint Helena,SHN,Oxford/AstraZeneca,2021-02-03,Government of Saint Helena,https://www.sainthelena.gov.sh/2021/news/covid-19-vaccination-programme-update/
 Saudi Arabia,SAU,Pfizer/BioNTech,2021-02-11,Saudi Health Council,https://coronamap.sa
 Scotland,,"Oxford/AstraZeneca, Pfizer/BioNTech",2021-02-11,Government of the United Kingdom,https://coronavirus.data.gov.uk/details/healthcare
-Serbia,SRB,"Pfizer/BioNTech, Sinopharm/Beijing, Sputnik V",2021-02-11,Government of Serbia,https://www.kurir.rs/amp/3622973/danas-tacno-2000-novozarazenih-najnoviji-korona-presek-u-srbiji-15-preminulih-raste-broj-pacijenata-na-respiratorima
+Serbia,SRB,"Pfizer/BioNTech, Sinopharm/Beijing, Sputnik V",2021-02-11,Government of Serbia,https:https://nova.rs/vesti/drustvo/u-srbiji-vakcinisano-803-319-ljudi/
 Seychelles,SYC,"Oxford/AstraZeneca, Sinopharm/Beijing",2021-02-11,Extended Programme for Immunisation,https://www.facebook.com/mohseychellesofficial/photos/1656020591265732
 Singapore,SGP,Pfizer/BioNTech,2021-02-10,Ministry of Health,https://www.pmo.gov.sg/Newsroom/Chinese-New-Year-Message-2021-by-PM-Lee-Hsien-Loong
 Slovakia,SVK,Pfizer/BioNTech,2021-02-12,Ministry of Health,https://covid-19.nczisk.sk


### PR DESCRIPTION
803.319 vaccinated 13.02.2021. 
https://nova.rs/vesti/drustvo/u-srbiji-vakcinisano-803-319-ljudi/