### PR TITLE
Serbia update

### DIFF
--- a/public/data/vaccinations/locations.csv
+++ b/public/data/vaccinations/locations.csv
@@ -75,7 +75,7 @@ Russia,RUS,Sputnik V,2021-02-10,Russian Direct Investment Fund,https://www.reute
 Saint Helena,SHN,Oxford/AstraZeneca,2021-02-03,Government of Saint Helena,https://www.sainthelena.gov.sh/2021/news/covid-19-vaccination-programme-update/
 Saudi Arabia,SAU,Pfizer/BioNTech,2021-02-16,Saudi Health Council,https://coronamap.sa
 Scotland,,"Oxford/AstraZeneca, Pfizer/BioNTech",2021-02-15,Government of the United Kingdom,https://coronavirus.data.gov.uk/details/healthcare
-Serbia,SRB,"Pfizer/BioNTech, Sinopharm/Beijing, Sputnik V",2021-02-13,Government of Serbia,https://www.blic.rs/vesti/drustvo/blizimo-se-cifri-od-800000-vakcinisanih-gradana-a-evo-koji-gradovi-danas-imaju/k0gmvln
+Serbia,SRB,"Pfizer/BioNTech, Sinopharm/Beijing, Sputnik V",2021-02-13,Government of Serbia,https://www.rtv.rs/sr_lat/drustvo/u-srbiji-945.989-vakcinacija-druga-u-evropi-sedma-u-svetu_1209637.html
 Seychelles,SYC,"Oxford/AstraZeneca, Sinopharm/Beijing",2021-02-13,Extended Programme for Immunisation,https://www.facebook.com/mohseychellesofficial/photos/1659483914252733
 Singapore,SGP,Pfizer/BioNTech,2021-02-10,Ministry of Health,https://www.pmo.gov.sg/Newsroom/Chinese-New-Year-Message-2021-by-PM-Lee-Hsien-Loong
 Slovakia,SVK,Pfizer/BioNTech,2021-02-15,Ministry of Health,https://github.com/Institut-Zdravotnych-Analyz/covid19-data


### PR DESCRIPTION
945.989 vaccinated until today(17.02.2021.)
https://www.rtv.rs/sr_lat/drustvo/u-srbiji-945.989-vakcinacija-druga-u-evropi-sedma-u-svetu_1209637.html

Fully vaccinated: 304.767 (until yesterday 16.02.2021) 
https://www.redportal.rs/srbija/12168/korona-u-srbiji-skoro-1900-novozarazenih-16-preminulo