### PR TITLE
Update Serbia

### DIFF
--- a/public/data/vaccinations/locations.csv
+++ b/public/data/vaccinations/locations.csv
@@ -80,7 +80,7 @@ Russia,RUS,Sputnik V,2021-02-10,Russian Direct Investment Fund,https://www.reute
 Saint Helena,SHN,Oxford/AstraZeneca,2021-02-03,Government of Saint Helena,https://www.sainthelena.gov.sh/2021/news/covid-19-vaccination-programme-update/
 Saudi Arabia,SAU,Pfizer/BioNTech,2021-02-18,Saudi Health Council,https://coronamap.sa
 Scotland,,"Oxford/AstraZeneca, Pfizer/BioNTech",2021-02-17,Government of the United Kingdom,https://coronavirus.data.gov.uk/details/healthcare
-Serbia,SRB,"Pfizer/BioNTech, Sinopharm/Beijing, Sputnik V",2021-02-17,Government of Serbia,https://www.rts.rs/page/stories/sr/%D0%9A%D0%BE%D1%80%D0%BE%D0%BD%D0%B0%D0%B2%D0%B8%D1%80%D1%83%D1%81/story/3134/koronavirus-u-srbiji/4261867/korona-srbija-podaci-zarazeni.html
+Serbia,SRB,"Pfizer/BioNTech, Sinopharm/Beijing, Sputnik V",2021-02-17,Government of Serbia,https://www.danas.rs/drustvo/krizni-stab-vakcinisano-1-111-000-gradjana-drugu-dozu-primilo-skoro-695-000/
 Seychelles,SYC,"Oxford/AstraZeneca, Sinopharm/Beijing",2021-02-17,Extended Programme for Immunisation,https://www.facebook.com/mohseychellesofficial/photos/1661847054016419
 Singapore,SGP,Pfizer/BioNTech,2021-02-10,Ministry of Health,https://www.pmo.gov.sg/Newsroom/Chinese-New-Year-Message-2021-by-PM-Lee-Hsien-Loong
 Slovakia,SVK,Pfizer/BioNTech,2021-02-18,Ministry of Health,https://github.com/Institut-Zdravotnych-Analyz/covid19-data


### PR DESCRIPTION
https://www.danas.rs/drustvo/krizni-stab-vakcinisano-1-111-000-gradjana-drugu-dozu-primilo-skoro-695-000/

1.111.000 vaccinated in Serbia 18.02.2021.
-----------------------------------------------
416.512 received only one dose
694.488 received two doses