### PR TITLE
Update Serbia

### DIFF
--- a/public/data/vaccinations/locations.csv
+++ b/public/data/vaccinations/locations.csv
@@ -87,7 +87,7 @@ Saint Helena,SHN,Oxford/AstraZeneca,2021-02-03,Government of Saint Helena,https:
 Saudi Arabia,SAU,Pfizer/BioNTech,2021-02-24,Saudi Health Council,https://covid19.moh.gov.sa/
 Scotland,,"Oxford/AstraZeneca, Pfizer/BioNTech",2021-02-24,Government of the United Kingdom,https://coronavirus.data.gov.uk/details/healthcare
 Senegal,SEN,Sinopharm/Beijing,2021-02-24,Ministry of Health,https://twitter.com/MinisteredelaS1/status/1364891086058045440
-Serbia,SRB,"Pfizer/BioNTech, Sinopharm/Beijing, Sputnik V",2021-02-25,Government of Serbia,https://www.rts.rs/page/stories/sr/%D0%9A%D0%BE%D1%80%D0%BE%D0%BD%D0%B0%D0%B2%D0%B8%D1%80%D1%83%D1%81/story/3134/koronavirus-u-srbiji/4272967/koronavirus-srbija-zarazeni-kovid-19-krizni-stab.html
+Serbia,SRB,"Pfizer/BioNTech, Sinopharm/Beijing, Sputnik V",2021-02-25,Government of Serbia,https://www.srbija.gov.rs/vest/en/168513/new-measures-against-coronavirus-in-force-for-the-weekend.php
 Seychelles,SYC,"Oxford/AstraZeneca, Sinopharm/Beijing",2021-02-23,Extended Programme for Immunisation,https://www.facebook.com/mohseychellesofficial/photos/1667419836792474
 Singapore,SGP,Pfizer/BioNTech,2021-02-18,Ministry of Health,https://www.moh.gov.sg/news-highlights/details/start-of-covid-19-vaccination-for-seniors
 Slovakia,SVK,Pfizer/BioNTech,2021-02-25,Ministry of Health,https://covid-19.nczisk.sk


### PR DESCRIPTION
https://www.srbija.gov.rs/vest/en/168513/new-measures-against-coronavirus-in-force-for-the-weekend.php

"Somewhat less than 1.4 billion people in Serbia have so far received a vaccine against the coronavirus, 507,000 have received both doses, and 886,086 received at least one dose, Kisic Tepavcevic said."