### PR TITLE
Update Panama.csv

### DIFF
--- a/public/data/vaccinations/country_data/Panama.csv
+++ b/public/data/vaccinations/country_data/Panama.csv
@@ -37,3 +37,5 @@ Panama,2021-02-22,Pfizer/BioNTech,https://twitter.com/EstrellaOnline/status/1364
 Panama,2021-02-23,Pfizer/BioNTech,https://twitter.com/EstrellaOnline/status/1364399919973425152,60088,,
 Panama,2021-02-24,Pfizer/BioNTech,https://twitter.com/EstrellaOnline/status/1364767051252985859,70578,,
 Panama,2021-02-25,Pfizer/BioNTech,https://twitter.com/EstrellaOnline/status/1365108039292977154,89419,,
+Panama,2021-02-26,Pfizer/BioNTech,https://twitter.com/EstrellaOnline/status/1365481973968498693,106667,,
+Panama,2021-02-27,Pfizer/BioNTech,https://twitter.com/EstrellaOnline/status/1365831351035973640,114529,,


### PR DESCRIPTION
Update of the vaccines of March 26 and 27, 2021 with the Pfizer-BioNTech vaccines in the Republic of Panama reported by the Panamanian press in the newspaper "La Estrella de Panamá"