### PR TITLE
Update Dominican Republic.csv

### DIFF
--- a/public/data/vaccinations/country_data/Dominican Republic.csv
+++ b/public/data/vaccinations/country_data/Dominican Republic.csv
@@ -7,3 +7,4 @@ Dominican Republic,2021-02-19,Oxford/AstraZeneca,https://twitter.com/luisabinade
 Dominican Republic,2021-02-20,Oxford/AstraZeneca,https://twitter.com/luisabinader/status/1363672938579439618,13087,13087,
 Dominican Republic,2021-02-21,Oxford/AstraZeneca,https://twitter.com/luisabinader/status/1363672938579439618,14264,14264,
 Dominican Republic,2021-02-24,Oxford/AstraZeneca,https://twitter.com/SaludPublicaRD/status/1364587633645617154,26400,26400,
+Dominican Republic,2021-02-24,Oxford/AstraZeneca,https://twitter.com/SaludPublicaRD/status/1367164847700475904,161827,161827,

--- a/public/data/vaccinations/country_data/Dominican Republic.csv
+++ b/public/data/vaccinations/country_data/Dominican Republic.csv
@@ -7,4 +7,4 @@ Dominican Republic,2021-02-19,Oxford/AstraZeneca,https://twitter.com/luisabinade
 Dominican Republic,2021-02-20,Oxford/AstraZeneca,https://twitter.com/luisabinader/status/1363672938579439618,13087,13087,
 Dominican Republic,2021-02-21,Oxford/AstraZeneca,https://twitter.com/luisabinader/status/1363672938579439618,14264,14264,
 Dominican Republic,2021-02-24,Oxford/AstraZeneca,https://twitter.com/SaludPublicaRD/status/1364587633645617154,26400,26400,
-Dominican Republic,2021-02-24,Oxford/AstraZeneca,https://twitter.com/SaludPublicaRD/status/1367164847700475904,161827,161827,
+Dominican Republic,2021-03-02,Oxford/AstraZeneca,https://twitter.com/SaludPublicaRD/status/1367164847700475904,161827,161827,


### PR DESCRIPTION
Hi, this an update from the number of inoculations in the dominican republic.

16-02-2021	385
17-02-2021	1,379
18-02-2021	5,328
19-02-2021	10,200
20-02-2021	13,087
21-02-2021	14,264
23-02-2021	19,117
24-02-2021	26,400
27-02-2021	60,000
28-02-2021	72,596
01-03-2021	105,984
02-03-2021	161,827

todays update: https://twitter.com/SaludPublicaRD/status/1367164847700475904