### PR TITLE
Serbia update

### DIFF
--- a/public/data/vaccinations/locations.csv
+++ b/public/data/vaccinations/locations.csv
@@ -98,7 +98,7 @@ San Marino,SMR,Sputnik V,2021-03-01,Social Security Institute,https://vaccinocov
 Saudi Arabia,SAU,"Oxford/AstraZeneca, Pfizer/BioNTech",2021-03-02,Saudi Health Council,https://coronamap.sa
 Scotland,,"Oxford/AstraZeneca, Pfizer/BioNTech",2021-03-01,Government of the United Kingdom,https://coronavirus.data.gov.uk/details/healthcare
 Senegal,SEN,Sinopharm/Beijing,2021-03-01,Ministry of Health,https://twitter.com/MinisteredelaS1/status/1366714148025950210
-Serbia,SRB,"Pfizer/BioNTech, Sinopharm/Beijing, Sputnik V",2021-03-02,Government of Serbia,https://www.rts.rs/page/stories/sr/%D0%9A%D0%BE%D1%80%D0%BE%D0%BD%D0%B0%D0%B2%D0%B8%D1%80%D1%83%D1%81/story/3134/koronavirus-u-srbiji/4279039/korona-srbija-podaci-zarazeni#shortStory-122262
+Serbia,SRB,"Pfizer/BioNTech, Sinopharm/Beijing, Sputnik V",2021-03-02,Government of Serbia,https://www.rts.rs/page/stories/sr/%D0%9A%D0%BE%D1%80%D0%BE%D0%BD%D0%B0%D0%B2%D0%B8%D1%80%D1%83%D1%81/story/3134/koronavirus-u-srbiji/4280365/korona-srbija-podaci-zarazeni.html
 Seychelles,SYC,"Oxford/AstraZeneca, Sinopharm/Beijing",2021-03-01,Extended Programme for Immunisation,https://www.facebook.com/mohseychellesofficial/photos/pcb.1672941029573688/1672940869573704/
 Singapore,SGP,Pfizer/BioNTech,2021-03-01,Ministry of Health,https://www.moh.gov.sg/covid-19
 Slovakia,SVK,Pfizer/BioNTech,2021-03-01,Ministry of Health,https://github.com/Institut-Zdravotnych-Analyz/covid19-data


### PR DESCRIPTION
1.535.274  doses administered
 534.751 fully vaccinated

https://www.rts.rs/page/stories/sr/%D0%9A%D0%BE%D1%80%D0%BE%D0%BD%D0%B0%D0%B2%D0%B8%D1%80%D1%83%D1%81/story/3134/koronavirus-u-srbiji/4280365/korona-srbija-podaci-zarazeni.html