### PR TITLE
Update Panama.csv

### DIFF
--- a/public/data/vaccinations/country_data/Panama.csv
+++ b/public/data/vaccinations/country_data/Panama.csv
@@ -44,3 +44,5 @@ Panama,2021-03-01,Pfizer/BioNTech,https://twitter.com/EstrellaOnline/status/1367
 Panama,2021-03-02,Pfizer/BioNTech,https://twitter.com/EstrellaOnline/status/1367293454255071233,128132,,
 Panama,2021-03-03,Pfizer/BioNTech,https://twitter.com/EstrellaOnline/status/1367293454255071233,132610,,
 Panama,2021-03-04,Pfizer/BioNTech,https://twitter.com/EstrellaOnline/status/1367724081051795456,150411,,
+Panama,2021-03-05,Pfizer/BioNTech,https://twitter.com/EstrellaOnline/status/1368403553723813889,166931,,
+Panama,2021-03-06,Pfizer/BioNTech,https://twitter.com/EstrellaOnline/status/1368403553723813889,194715,,


### PR DESCRIPTION
update of the COVID-19 vaccines in the Republic of Panama corresponding to Friday, March 5 and Saturday, March 6, 2021, published on the Twitter account of the newspaper La Estrella de Panamá