### PR TITLE
Update Serbia

### DIFF
--- a/public/data/vaccinations/locations.csv
+++ b/public/data/vaccinations/locations.csv
@@ -100,7 +100,7 @@ San Marino,SMR,Sputnik V,2021-03-04,Social Security Institute,https://vaccinocov
 Saudi Arabia,SAU,"Oxford/AstraZeneca, Pfizer/BioNTech",2021-03-05,Saudi Health Council,https://coronamap.sa
 Scotland,,"Oxford/AstraZeneca, Pfizer/BioNTech",2021-03-04,Government of the United Kingdom,https://coronavirus.data.gov.uk/details/healthcare
 Senegal,SEN,Sinopharm/Beijing,2021-03-04,Ministry of Health,https://twitter.com/MinisteredelaS1/status/1367779932399673344/photo/2
-Serbia,SRB,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinopharm/Beijing, Sputnik V",2021-03-05,Government of Serbia,https://www.rts.rs/page/stories/sr/%D0%9A%D0%BE%D1%80%D0%BE%D0%BD%D0%B0%D0%B2%D0%B8%D1%80%D1%83%D1%81/story/3134/koronavirus-u-srbiji/4283653/srbija-koronavirus-predrag-kon-branislav-tiodorovic.html
+Serbia,SRB,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinopharm/Beijing, Sputnik V",2021-03-05,Government of Serbia,https://www.rts.rs/page/stories/sr/%D0%9A%D0%BE%D1%80%D0%BE%D0%BD%D0%B0%D0%B2%D0%B8%D1%80%D1%83%D1%81/story/3134/koronavirus-u-srbiji/4284271/koronavirus-srbija-broj-zarazenih-preminulih-mere-vakcinacija-.html
 Seychelles,SYC,"Oxford/AstraZeneca, Sinopharm/Beijing",2021-03-05,Extended Programme for Immunisation,https://www.facebook.com/mohseychellesofficial/photos/pcb.1675550692646055/1675550642646060
 Singapore,SGP,Pfizer/BioNTech,2021-03-04,Ministry of Health,https://www.straitstimes.com/singapore/politics/budget-debate-more-than-350000-singapore-residents-have-received-their-first
 Slovakia,SVK,Pfizer/BioNTech,2021-03-04,Ministry of Health,https://github.com/Institut-Zdravotnych-Analyz/covid19-data


### PR DESCRIPTION
https://www.rts.rs/page/stories/sr/%D0%9A%D0%BE%D1%80%D0%BE%D0%BD%D0%B0%D0%B2%D0%B8%D1%80%D1%83%D1%81/story/3134/koronavirus-u-srbiji/4284271/koronavirus-srbija-broj-zarazenih-preminulih-mere-vakcinacija-.html

1.650.030 doses administered
620.067 fully vaccinated