### PR TITLE
Update Panama.csv

### DIFF
--- a/public/data/vaccinations/country_data/Panama.csv
+++ b/public/data/vaccinations/country_data/Panama.csv
@@ -48,3 +48,4 @@ Panama,2021-03-05,Pfizer/BioNTech,https://twitter.com/EstrellaOnline/status/1368
 Panama,2021-03-06,Pfizer/BioNTech,https://twitter.com/EstrellaOnline/status/1368403553723813889,194715,,
 Panama,2021-03-07,Pfizer/BioNTech,https://twitter.com/EstrellaOnline/status/1368746204566331392/photo/1,208415,,
 Panama,2021-03-08,Pfizer/BioNTech,https://twitter.com/EstrellaOnline/status/1369228979740278784,211751,,
+Panama,2021-03-09,Pfizer/BioNTech,https://twitter.com/EstrellaOnline/status/1369470587375075329,214492,,


### PR DESCRIPTION
Covid-19 vaccination update in the Republic of Panama corresponding to March 9, 2020 reported in the newspaper La Estrella de Panamá.