### PR TITLE
Serbia updare

### DIFF
--- a/public/data/vaccinations/locations.csv
+++ b/public/data/vaccinations/locations.csv
@@ -105,7 +105,7 @@ San Marino,SMR,Sputnik V,2021-03-08,Social Security Institute,https://vaccinocov
 Saudi Arabia,SAU,"Oxford/AstraZeneca, Pfizer/BioNTech",2021-03-09,Saudi Health Council,https://coronamap.sa
 Scotland,,"Oxford/AstraZeneca, Pfizer/BioNTech",2021-03-08,Government of the United Kingdom,https://coronavirus.data.gov.uk/details/healthcare
 Senegal,SEN,Sinopharm/Beijing,2021-03-09,Ministry of Health,https://twitter.com/MinisteredelaS1/status/1369591093134831620
-Serbia,SRB,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinopharm/Beijing, Sputnik V",2021-03-09,Government of Serbia,https://www.rts.rs/page/stories/sr/%D0%9A%D0%BE%D1%80%D0%BE%D0%BD%D0%B0%D0%B2%D0%B8%D1%80%D1%83%D1%81/story/3134/koronavirus-u-srbiji/4287680/korona-srbija-podaci-zarazeni.html
+Serbia,SRB,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinopharm/Beijing, Sputnik V",2021-03-09,Government of Serbia,https://www.rts.rs/page/stories/sr/%D0%9A%D0%BE%D1%80%D0%BE%D0%BD%D0%B0%D0%B2%D0%B8%D1%80%D1%83%D1%81/story/3134/koronavirus-u-srbiji/4289341/korona-srbija-podaci-zarazeni#shortStory-124795
 Seychelles,SYC,"Oxford/AstraZeneca, Sinopharm/Beijing",2021-03-09,Extended Programme for Immunisation,https://www.facebook.com/mohseychellesofficial/photos/pcb.1679349568932834/1679349362266188/
 Singapore,SGP,Pfizer/BioNTech,2021-03-08,Ministry of Health,https://www.moh.gov.sg/covid-19
 Slovakia,SVK,Pfizer/BioNTech,2021-03-09,Ministry of Health,https://covid-19.nczisk.sk


### PR DESCRIPTION
https://www.rts.rs/page/stories/sr/%D0%9A%D0%BE%D1%80%D0%BE%D0%BD%D0%B0%D0%B2%D0%B8%D1%80%D1%83%D1%81/story/3134/koronavirus-u-srbiji/4289341/korona-srbija-podaci-zarazeni#shortStory-124795

1.792.912 doses administered
647.019 fully vaccinated