### PR TITLE
Colombia.py Fix

### DIFF
--- a/scripts/scripts/vaccinations/automations/incremental/colombia.py
+++ b/scripts/scripts/vaccinations/automations/incremental/colombia.py
@@ -26,10 +26,7 @@ def getImageURL(hostname, path):
     return hostname + soup.find("div", {"class": "interSec1Lchikun left"}).find('img')['src']
 
 
-def processImg(url):
-    img = imutils.url_to_image(url)
-    img = img[299:389, 105:616] # crops the image to a specific position [y1:y2, x1:x2]
-                                # in this case, it's cropping the image to the amount of applied vaccines position
+def processImg(img):
     img_gray = cv2.cvtColor(img, cv2.COLOR_RGB2GRAY)
     img_gray, img_bin = cv2.threshold(img_gray,128,255,cv2.THRESH_BINARY | cv2.THRESH_OTSU)
     img_gray = cv2.bitwise_not(img_bin)
@@ -39,9 +36,21 @@ def processImg(url):
     # credit to hucker marius for this portion of code. 
     # this literally saved my life since imutils' tools weren't working the way i expected
     # https://towardsdatascience.com/optical-character-recognition-ocr-with-less-than-12-lines-of-code-using-python-48404218cccb
-    # cv2.imwrite("img.jpeg", img)
-    return getImgText(img)
+    
+    return img
 
+def getImages(url):
+    full_img = imutils.url_to_image(url)
+
+    vaccinated = processImg(full_img[249:310, 115:612]) # amount of applied vaccinations
+    second_doses = processImg(full_img[1004:1059, 120:612]) # amount of second doses applied
+    # full_img[y1:y2, x1:x2] crops the image to a specific position
+
+    # cv2.imwrite("vaccinated.jpeg", vaccinated)
+    # cv2.imwrite("second_doses.jpeg", second_doses)
+    ## Only uncomment these to troubleshoot!
+
+    return getImgText(vaccinated), getImgText(second_doses)
 
 def main():
 
@@ -57,17 +66,26 @@ def main():
     imgURL = getImageURL(hostname, path)
 
     # Process Image
-    imgText = processImg(imgURL)
+    imgText = getImages(imgURL)
+    total_vaccinations = imgText[0]
+    people_fully_vaccinated = imgText[1]
+    # print(imgText)
 
     # Eliminates all the involved strings if there's any
-    # print(imgText)
-    total_vaccinations = int(re.sub(r"[^\d]", "", imgText))
-    # print("Vaccinated: %i" % (total_vaccinations))
-    data["total_vaccinations"] = total_vaccinations
+    total_vaccinations = int(re.sub(r"[^\d]", "", total_vaccinations))
+    people_fully_vaccinated = int(re.sub(r"[^\d]", "", people_fully_vaccinated))
+    # print("Total of vaccinations: %i" % (total_vaccinations))
+    # print("Fully vaccinated: %i" % (people_fully_vaccinated))
+    
+    data["total_vaccinations"] = total_vaccinations # the government counts both first AND second doses in total vaccinations
+    data["people_vaccinated"] = total_vaccinations - people_fully_vaccinated
+    data["people_fully_vaccinated"] = people_fully_vaccinated
 
     vaxutils.increment(
         location=data["location"],
         total_vaccinations=data["total_vaccinations"],
+        people_vaccinated=data["people_vaccinated"],
+        people_fully_vaccinated=data["people_fully_vaccinated"],
         date=data["date"],
         source_url=data["source_url"],
         vaccine=data["vaccine"]

--- a/scripts/scripts/vaccinations/automations/output/Colombia.csv
+++ b/scripts/scripts/vaccinations/automations/output/Colombia.csv
@@ -22,3 +22,4 @@ Colombia,2021-03-07,"Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud
 Colombia,2021-03-08,"Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,316079,,
 Colombia,2021-03-09,"Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,360635,,
 Colombia,2021-03-10,"Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,480250,,
+Colombia,2021-03-11,"Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,589208,580060.0,9148.0


### PR DESCRIPTION
I assume colombia.py broke since the government changed the style of the image just so they can fit in the second doses part causing some problems with pytesseract, which is why I'm here.
I fixed that, did some small tweaking, and added support for the second doses.

The government counts both first AND second doses in the total vaccinations part, so for people_vaccinated it subtracts total_vaccinations with people_fully_vaccinated. Feel free to correct it if it isn't that way.

~and no, the government hasn't reported vaccine data separate from an image yet 😔.~
Cheers!