### PR TITLE
Update Panama.csv

### DIFF
--- a/public/data/vaccinations/country_data/Panama.csv
+++ b/public/data/vaccinations/country_data/Panama.csv
@@ -54,3 +54,4 @@ Panama,2021-03-11,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1370185311
 Panama,2021-03-12,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1370521877278494720/photo/1,245177,,
 Panama,2021-03-13,Pfizer/BioNTech,https://twitter.com/EstrellaOnline/status/1371105449358073871/photo/1,252313,,
 Panama,2021-03-14,Pfizer/BioNTech,https://twitter.com/EstrellaOnline/status/1371433758637834242/photo/1,253800,,
+Panama,2021-03-15,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1371632651845664769,259843,,


### PR DESCRIPTION
Covid-19 vaccination update in the Republic of Panama as of March 15, 2021, by the Ministry of Health of the Republic of Panama. Is published in the Ministry of Health because The newspaper La Estrella de Panamá did not publish the graph on the morning of Tuesday, March 16, 2021.I would also request that all the information be from the Ministry of Health as the official entity in charge of the country's health and not from a newspaper.