### PR TITLE
Update Panama.csv

### DIFF
--- a/public/data/vaccinations/country_data/Panama.csv
+++ b/public/data/vaccinations/country_data/Panama.csv
@@ -55,3 +55,4 @@ Panama,2021-03-12,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1370521877
 Panama,2021-03-13,Pfizer/BioNTech,https://twitter.com/EstrellaOnline/status/1371105449358073871/photo/1,252313,,
 Panama,2021-03-14,Pfizer/BioNTech,https://twitter.com/EstrellaOnline/status/1371433758637834242/photo/1,253800,,
 Panama,2021-03-15,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1371632651845664769,259843,,
+Panama,2021-03-16,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1371991871925460992,266298,,


### PR DESCRIPTION
Update of the vaccination against COVID-19 in the Republic of Panama corresponding to March 16, 2021 in Communiqué # 385 of the Ministry of Health of Panama on its Twitter account.