### PR TITLE
Serbia update

### DIFF
--- a/public/data/vaccinations/locations.csv
+++ b/public/data/vaccinations/locations.csv
@@ -110,7 +110,7 @@ San Marino,SMR,Sputnik V,2021-03-15,Social Security Institute,https://vaccinocov
 Saudi Arabia,SAU,"Oxford/AstraZeneca, Pfizer/BioNTech",2021-03-16,Saudi Health Council,https://coronamap.sa
 Scotland,OWID_SCT,"Oxford/AstraZeneca, Pfizer/BioNTech",2021-03-15,Government of the United Kingdom,https://coronavirus.data.gov.uk/details/healthcare
 Senegal,SEN,Sinopharm/Beijing,2021-03-15,Ministry of Health,https://twitter.com/MinisteredelaS1/status/1371769651244507139
-Serbia,SRB,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinopharm/Beijing, Sputnik V",2021-03-15,Government of Serbia,https://www.rts.rs/page/stories/sr/%D0%9A%D0%BE%D1%80%D0%BE%D0%BD%D0%B0%D0%B2%D0%B8%D1%80%D1%83%D1%81/story/3134/koronavirus-u-srbiji/4295816/koronavirus-kovid-19-vakcine-srbija-epidemija.html
+Serbia,SRB,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinopharm/Beijing, Sputnik V",2021-03-15,Government of Serbia,https://www.rts.rs/page/stories/sr/%D0%9A%D0%BE%D1%80%D0%BE%D0%BD%D0%B0%D0%B2%D0%B8%D1%80%D1%83%D1%81/story/3134/koronavirus-u-srbiji/4297614/koronavirus-srbija-podaci-17.-mart.html
 Seychelles,SYC,"Oxford/AstraZeneca, Sinopharm/Beijing",2021-03-11,Extended Programme for Immunisation,https://www.facebook.com/mohseychellesofficial/photos/pcb.1682413525293105/1682413471959777/
 Singapore,SGP,Pfizer/BioNTech,2021-03-15,Ministry of Health,https://www.moh.gov.sg/covid-19
 Slovakia,SVK,Pfizer/BioNTech,2021-03-15,Ministry of Health,https://github.com/Institut-Zdravotnych-Analyz/covid19-data


### PR DESCRIPTION
https://www.rts.rs/page/stories/sr/%D0%9A%D0%BE%D1%80%D0%BE%D0%BD%D0%B0%D0%B2%D0%B8%D1%80%D1%83%D1%81/story/3134/koronavirus-u-srbiji/4297614/koronavirus-srbija-podaci-17.-mart.html

 2.077.197   doses administered
809.375 fully vaccinated