### PR TITLE
Update Panama.csv

### DIFF
--- a/public/data/vaccinations/country_data/Panama.csv
+++ b/public/data/vaccinations/country_data/Panama.csv
@@ -56,3 +56,4 @@ Panama,2021-03-13,Pfizer/BioNTech,https://twitter.com/EstrellaOnline/status/1371
 Panama,2021-03-14,Pfizer/BioNTech,https://twitter.com/EstrellaOnline/status/1371433758637834242/photo/1,253800,,
 Panama,2021-03-15,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1371632651845664769,259843,,
 Panama,2021-03-16,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1371991695039082498,266298,,
+Panama,2021-03-18,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1372715275716558855,287086,,


### PR DESCRIPTION
Covid-19 vaccination update in the Republic of Panama corresponding to March 18, 2021 by the Ministry of Health of the Republic of Panama on its Twitter account