### PR TITLE
Update Philippines.csv

### DIFF
--- a/public/data/vaccinations/country_data/Philippines.csv
+++ b/public/data/vaccinations/country_data/Philippines.csv
@@ -1,9 +1,9 @@
 location,date,vaccine,source_url,total_vaccinations,people_vaccinated,people_fully_vaccinated
 Philippines,2021-02-28,Sinovac,https://www.rappler.com/nation/philippines-begins-legally-rolling-out-covid-19-vaccine-march-1-2021,0,0,0
 Philippines,2021-03-02,Sinovac,https://newsinfo.inquirer.net/1402323/over-2700-get-covid-19-vaccine-after-two-days-of-rollout-vaccine-czar,2793,2793,0
-Philippines,2021-03-07,Sinovac,https://newsinfo.inquirer.net/1404416/over-29k-vaccinated-so-far-against-covid-19-in-ph-palace,29266,29266,0
-Philippines,2021-03-08,Sinovac,https://newsinfo.inquirer.net/1404600/ph-so-far-administered-40000-vaccine-doses-vs-covid-19,44000,44000,0
-Philippines,2021-03-10,Sinovac,https://newsinfo.inquirer.net/1405856/palace-ph-inoculates-over-114500-people-vs-covid-19-as-of-march-10,114500,114500,0
-Philippines,2021-03-15,Sinovac,https://radyo.inquirer.net/287245/bilang-ng-nabakunahan-laban-sa-covid-19-sa-pilipinas-nasa-215997-na,215997,215997,0
-Philippines,2021-03-18,Sinovac,https://pcoo.gov.ph/OPS-content/press-briefing-of-presidential-spokesperson-harry-roque-132/,240297,240297,0
-Philippines,2021-03-22,Sinovac,https://news.abs-cbn.com/news/03/22/21/doh-says-over-336000-health-workers-vaccinated,336656,336656,0
+Philippines,2021-03-07,"Oxford/AstraZeneca, Sinovac",https://newsinfo.inquirer.net/1404416/over-29k-vaccinated-so-far-against-covid-19-in-ph-palace,29266,29266,0
+Philippines,2021-03-08,"Oxford/AstraZeneca, Sinovac",https://newsinfo.inquirer.net/1404600/ph-so-far-administered-40000-vaccine-doses-vs-covid-19,44000,44000,0
+Philippines,2021-03-10,"Oxford/AstraZeneca, Sinovac",https://newsinfo.inquirer.net/1405856/palace-ph-inoculates-over-114500-people-vs-covid-19-as-of-march-10,114500,114500,0
+Philippines,2021-03-15,"Oxford/AstraZeneca, Sinovac",https://radyo.inquirer.net/287245/bilang-ng-nabakunahan-laban-sa-covid-19-sa-pilipinas-nasa-215997-na,215997,215997,0
+Philippines,2021-03-18,"Oxford/AstraZeneca, Sinovac",https://pcoo.gov.ph/OPS-content/press-briefing-of-presidential-spokesperson-harry-roque-132/,240297,240297,0
+Philippines,2021-03-22,"Oxford/AstraZeneca, Sinovac",https://news.abs-cbn.com/news/03/22/21/doh-says-over-336000-health-workers-vaccinated,336656,336656,0


### PR DESCRIPTION
AstraZeneca vaccines arrived in the Philippines last March 4 and has been used since then.

Source: https://www.cnnphilippines.com/news/2021/3/4/AstraZeneca-vaccine-COVAX-facility-arrival.html