### PR TITLE
Update Panama.csv

### DIFF
--- a/public/data/vaccinations/country_data/Panama.csv
+++ b/public/data/vaccinations/country_data/Panama.csv
@@ -60,3 +60,5 @@ Panama,2021-03-18,Pfizer/BioNTech,https://twitter.com/EstrellaOnline/status/1372
 Panama,2021-03-19,Pfizer/BioNTech,https://twitter.com/EstrellaOnline/status/1373205202216611841,297165,,
 Panama,2021-03-20,Pfizer/BioNTech,https://twitter.com/EstrellaOnline/status/1373648935877816328,309324,,
 Panama,2021-03-21,Pfizer/BioNTech,https://twitter.com/EstrellaOnline/status/1373999176644755457,309660,,
+Panama,2021-03-22,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1374158652534362116,310108,,
+Panama,2021-03-23,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1374546941422501890,312761,,


### PR DESCRIPTION
Vaccination update against COVID-19 in the Republic of Panama corresponding to March 22 and 23, 2021 by the Ministry of Health since the La Estrella de Panamá newspaper has not published it.