### PR TITLE
Update Panama.csv

### DIFF
--- a/public/data/vaccinations/country_data/Panama.csv
+++ b/public/data/vaccinations/country_data/Panama.csv
@@ -60,3 +60,6 @@ Panama,2021-03-18,Pfizer/BioNTech,https://twitter.com/EstrellaOnline/status/1372
 Panama,2021-03-19,Pfizer/BioNTech,https://twitter.com/EstrellaOnline/status/1373205202216611841,297165,,
 Panama,2021-03-20,Pfizer/BioNTech,https://twitter.com/EstrellaOnline/status/1373648935877816328,309324,,
 Panama,2021-03-21,Pfizer/BioNTech,https://twitter.com/EstrellaOnline/status/1373999176644755457,309660,,
+Panama,2021-03-22,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1374158652534362116,310108,,
+Panama,2021-03-23,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1374546941422501890,312761,,
+Panama,2021-03-24,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1374858925162520577,320079,,


### PR DESCRIPTION
Update of the vaccination against COVID-19 in the Republic of Panama corresponding to March 22, 23 and 24, 2021 reported by the Ministry of Health on its Twitter account. The newspaper La Estrella de Panamá has not published information on its social networks or in the newspaper, so it opted for the information contained in the daily Communiqués of the Health Authority.