### PR TITLE
Update Panama.csv

### DIFF
--- a/public/data/vaccinations/country_data/Panama.csv
+++ b/public/data/vaccinations/country_data/Panama.csv
@@ -63,3 +63,4 @@ Panama,2021-03-21,Pfizer/BioNTech,https://twitter.com/EstrellaOnline/status/1373
 Panama,2021-03-22,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1374158652534362116,310108,,
 Panama,2021-03-23,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1374546941422501890,312761,,
 Panama,2021-03-24,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1374858925162520577,320079,,
+Panama,2021-03-25,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1375225055714623488,329822,,


### PR DESCRIPTION
update of the vaccination against covid-19 in the Republic of Panama to March 25, 2021 updated by the Ministry of Health. The source of the Ministry of Health will be used momentarily.Since the newspaper La Estrella de Panamá has not published the updates since the 20th