### PR TITLE
Update Panama.csv

### DIFF
--- a/public/data/vaccinations/country_data/Panama.csv
+++ b/public/data/vaccinations/country_data/Panama.csv
@@ -66,3 +66,4 @@ Panama,2021-03-24,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1374858925
 Panama,2021-03-25,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1375225055714623488,329822,,
 Panama,2021-03-26,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1375583976727977985,342716,,
 Panama,2021-03-27,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1375970370679930880,352876,,
+Panama,2021-03-28,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1376326017917333507,357431,,


### PR DESCRIPTION
Update of the vaccination against COVID-19 in the Republic of Panama corresponding to March 28, 2021 by the Ministry of Health. Government Health and technology authorities what next month they will have the vaccine meter in real time