### PR TITLE
Dominican Republic.csv Correction

### DIFF
--- a/public/data/vaccinations/country_data/Dominican Republic.csv
+++ b/public/data/vaccinations/country_data/Dominican Republic.csv
@@ -19,5 +19,5 @@ Dominican Republic,2021-03-10,"Oxford/AstraZeneca, Sinovac",https://twitter.com/
 Dominican Republic,2021-03-11,"Oxford/AstraZeneca, Sinovac",https://twitter.com/SaludPublicaRD/status/1370115374373560325,606006,606006,
 Dominican Republic,2021-03-15,"Oxford/AstraZeneca, Sinovac",https://twitter.com/SaludPublicaRD/status/1371444361469255682,675000,675000,
 Dominican Republic,2021-03-23,"Oxford/AstraZeneca, Sinovac",https://twitter.com/SaludPublicaRD/status/1374451963627151360,800000,800000,
-Dominican Republic,2021-03-29,"Oxford/AstraZeneca, Sinovac",https://twitter.com/SaludPublicaRD/status/1376584237852282882,890194,870134,20060
-Dominican Republic,2021-03-30,"Oxford/AstraZeneca, Sinovac",https://twitter.com/SaludPublicaRD/status/1376919663049904145,965264,910869,54395
+Dominican Republic,2021-03-29,"Oxford/AstraZeneca, Sinovac",https://twitter.com/SaludPublicaRD/status/1376584237852282882,870134,850074,20060
+Dominican Republic,2021-03-30,"Oxford/AstraZeneca, Sinovac",https://twitter.com/SaludPublicaRD/status/1376919663049904145,910869,856474,54395


### PR DESCRIPTION
Hi @edomt I think that the last two tweets haven't been interpreted correctly.  
For 2021-03-30 the tweet says "To date, we have applied a total of 910,869 doses, of which 54,395 correspond to the second administration". Based on that there must be 856,474 people with at least one dose.
I think that the same logic must be used for 2021-03-29 because otherwise we would get a negative change (comparing March 30 with 29) in people with at least one dose.
Or maybe I haven't interpreted your fields correctly. Please let me know if that is the case. Thank you. 