### PR TITLE
Vaccination/Czechia: AstraZeneca renamed to VAXZEVRIA

### DIFF
--- a/scripts/scripts/vaccinations/automations/batch/czechia.py
+++ b/scripts/scripts/vaccinations/automations/batch/czechia.py
@@ -15,7 +15,7 @@ from utils.pipeline import enrich_total_vaccinations
 vaccine_mapping = {
     "Comirnaty": "Pfizer/BioNTech",
     "COVID-19 Vaccine Moderna": "Moderna",
-    "COVID-19 Vaccine AstraZeneca": "Oxford/AstraZeneca",
+    "VAXZEVRIA": "Oxford/AstraZeneca",
 }
 
 


### PR DESCRIPTION
After the vaccine [was renamed](https://www.ema.europa.eu/en/documents/product-information/vaxzevria-previously-covid-19-vaccine-astrazeneca-epar-product-information_en.pdf), the Czech health ministry renamed it in its data as well.

The pipeline checks unique values in the `vaccine_name` column, so it was crashing, it isn't with this patch.