### PR TITLE
Update Serbia

### DIFF
--- a/public/data/vaccinations/locations.csv
+++ b/public/data/vaccinations/locations.csv
@@ -130,7 +130,7 @@ Sao Tome and Principe,STP,Oxford/AstraZeneca,2021-03-29,Ministry of Health,https
 Saudi Arabia,SAU,"Oxford/AstraZeneca, Pfizer/BioNTech",2021-03-30,Saudi Health Council,https://coronamap.sa
 Scotland,OWID_SCT,"Oxford/AstraZeneca, Pfizer/BioNTech",2021-03-29,Government of the United Kingdom,https://coronavirus.data.gov.uk/details/healthcare
 Senegal,SEN,Sinopharm/Beijing,2021-03-30,Ministry of Health,https://twitter.com/MinisteredelaS1/status/1376840141306744839
-Serbia,SRB,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinopharm/Beijing, Sputnik V",2021-03-30,Government of Serbia,https://www.alo.rs/vesti/drustvo/do-sada-milion-gradana-primilo-obe-doze-vakcine/400845/vest
+Serbia,SRB,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinopharm/Beijing, Sputnik V",2021-03-30,Government of Serbia,https://www.rts.rs/page/stories/sr/%D0%9A%D0%BE%D1%80%D0%BE%D0%BD%D0%B0%D0%B2%D0%B8%D1%80%D1%83%D1%81/story/3134/koronavirus-u-srbiji/4316187/koronavirus-kovid-19-podaci-31.-art-2021.vakcine-srbija-epidemija.html
 Seychelles,SYC,"Oxford/AstraZeneca, Sinopharm/Beijing",2021-03-30,Extended Programme for Immunisation,https://www.facebook.com/mohseychellesofficial/photos/pcb.1701008690100255/1701008160100308
 Sierra Leone,SLE,Oxford/AstraZeneca,2021-03-25,Ministry of Health and Sanitation,https://www.facebook.com/mohsict/photos/pcb.1359260857768390/1359260657768410/
 Singapore,SGP,"Moderna, Pfizer/BioNTech",2021-03-29,Ministry of Health,https://www.moh.gov.sg/covid-19


### PR DESCRIPTION
https://www.rts.rs/page/stories/sr/%D0%9A%D0%BE%D1%80%D0%BE%D0%BD%D0%B0%D0%B2%D0%B8%D1%80%D1%83%D1%81/story/3134/koronavirus-u-srbiji/4316187/koronavirus-kovid-19-podaci-31.-art-2021.vakcine-srbija-epidemija.html

2.444.395 doses administered
1.015.507 fully vaccinated