### PR TITLE
Update Panama.csv

### DIFF
--- a/public/data/vaccinations/country_data/Panama.csv
+++ b/public/data/vaccinations/country_data/Panama.csv
@@ -66,6 +66,8 @@ Panama,2021-03-24,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1374858925
 Panama,2021-03-25,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1375225055714623488,329822,,
 Panama,2021-03-26,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1375583976727977985,342716,,
 Panama,2021-03-27,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1375970370679930880,352876,,
-Panama,2021-03-28,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1376326017917333507/photo/3,357431,,
-Panama,2021-03-29,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1376662708737675300/photo/3,358277,,
-Panama,2021-03-30,Pfizer/BioNTech,https://fb.watch/4zFbSC-ruH/,364079,247539,116540
+Panama,2021-03-28,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1376326017917333507,357431,,
+Panama,2021-03-29,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1376662708737675300,358277,,
+Panama,2021-03-30,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1377060139803545601,364079,,
+Panama,2021-03-31,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1377402299572613121,370793,,
+Panama,2021-04-01,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1377778846490054656,373491,,


### PR DESCRIPTION
Vaccination update against COVID-19 in the Republic of Panama corresponding to March 30 and 31 and April 1 by the Ministry of Health of Panama.