### PR TITLE
Update Serbia

### DIFF
--- a/public/data/vaccinations/locations.csv
+++ b/public/data/vaccinations/locations.csv
@@ -131,7 +131,7 @@ Sao Tome and Principe,STP,Oxford/AstraZeneca,2021-03-29,Ministry of Health,https
 Saudi Arabia,SAU,"Oxford/AstraZeneca, Pfizer/BioNTech",2021-04-01,Saudi Health Council,https://coronamap.sa
 Scotland,OWID_SCT,"Oxford/AstraZeneca, Pfizer/BioNTech",2021-03-31,Government of the United Kingdom,https://coronavirus.data.gov.uk/details/healthcare
 Senegal,SEN,Sinopharm/Beijing,2021-04-01,Ministry of Health,https://twitter.com/MinisteredelaS1/status/1377564337829781504
-Serbia,SRB,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinopharm/Beijing, Sputnik V",2021-04-01,Government of Serbia,https://www.rts.rs/page/stories/sr/%D0%9A%D0%BE%D1%80%D0%BE%D0%BD%D0%B0%D0%B2%D0%B8%D1%80%D1%83%D1%81/story/3134/koronavirus-u-srbiji/4316979/koronavirus-srbija-podaci-1.-april-2021..html
+Serbia,SRB,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinopharm/Beijing, Sputnik V",2021-04-01,Government of Serbia,https://www.rts.rs/page/stories/sr/%D0%9A%D0%BE%D1%80%D0%BE%D0%BD%D0%B0%D0%B2%D0%B8%D1%80%D1%83%D1%81/story/3134/koronavirus-u-srbiji/4318077/korona-srbija-podaci-.-april-2021..html
 Seychelles,SYC,"Oxford/AstraZeneca, Sinopharm/Beijing",2021-04-01,Extended Programme for Immunisation,https://www.facebook.com/mohseychellesofficial/photos/pcb.1702967219904402/1702967099904414/
 Sierra Leone,SLE,Oxford/AstraZeneca,2021-03-30,Ministry of Health and Sanitation,https://www.facebook.com/mohsict/photos/pcb.1362532444107898/1362532254107917/
 Singapore,SGP,"Moderna, Pfizer/BioNTech",2021-03-29,Ministry of Health,https://www.moh.gov.sg/covid-19


### PR DESCRIPTION
https://www.rts.rs/page/stories/sr/%D0%9A%D0%BE%D1%80%D0%BE%D0%BD%D0%B0%D0%B2%D0%B8%D1%80%D1%83%D1%81/story/3134/koronavirus-u-srbiji/4318077/korona-srbija-podaci-.-april-2021..html

2.521.863 doses administered
1.063.559 fully vaccinated