### PR TITLE
Update Panama.csv

### DIFF
--- a/public/data/vaccinations/country_data/Panama.csv
+++ b/public/data/vaccinations/country_data/Panama.csv
@@ -72,3 +72,4 @@ Panama,2021-03-30,Pfizer/BioNTech,https://fb.watch/4zFbSC-ruH/,364079,247539,116
 Panama,2021-03-31,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1377402299572613121/photo/1,370793,,
 Panama,2021-04-01,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1377778846490054656/photo/2,373491,,
 Panama,2021-04-05,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1379229927845810177/photo/1,387580,266754,120826
+Panama,2021-04-06,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1379615388573519874/photo/2,408618,280510,128108


### PR DESCRIPTION
Vaccination update against COVID-19 in the Republic of Panama corresponding to April 6, 2021 communicated by the Ministry of Health and by the official page https://vacunas.panamasolidario.gob.pa/vacunometro/