### PR TITLE
Update Bolivia.csv

### DIFF
--- a/public/data/vaccinations/country_data/Bolivia.csv
+++ b/public/data/vaccinations/country_data/Bolivia.csv
@@ -40,3 +40,6 @@ Bolivia,2021-03-31,Sputnik V,https://twitter.com/SaludDeportesBo/status/13774406
 Bolivia,2021-04-01,Sputnik V,https://twitter.com/SaludDeportesBo/status/1377802182943211520,318115,203103,115012
 Bolivia,2021-04-02,Sputnik V,https://twitter.com/SaludDeportesBo/status/1378155914079956995,320065,204097,115968
 Bolivia,2021-04-03,Sputnik V,https://twitter.com/SaludDeportesBo/status/1378523646344495105,321807,205115,116692
+Bolivia,2021-04-04,Sputnik V, Sinopharm, AstraZeneca,https://twitter.com/SaludDeportesBo/status/1378881476683571206,323081,206003,117078
+Bolivia,2021-04-05,Sputnik V, Sinopharm, AstraZeneca,https://twitter.com/SaludDeportesBo/status/1379264587577622533,339633,215926,123707
+Bolivia,2021-04-06,Sputnik V, Sinopharm, AstraZeneca,https://twitter.com/SaludDeportesBo/status/1379615780485074944,357924,229556,128368


### PR DESCRIPTION
Vaccination update against COVID-19 in the Plurinational State of Bolivia corresponding to April 4, 5, and 6, 2021 by the Ministry of Health and Sports.