### PR TITLE
Update Panama.csv

### DIFF
--- a/public/data/vaccinations/country_data/Panama.csv
+++ b/public/data/vaccinations/country_data/Panama.csv
@@ -71,4 +71,6 @@ Panama,2021-03-29,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1376662708
 Panama,2021-03-30,Pfizer/BioNTech,https://fb.watch/4zFbSC-ruH/,364079,247539,116540
 Panama,2021-03-31,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1377402299572613121/photo/1,370793,,
 Panama,2021-04-01,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1377778846490054656/photo/2,373491,,
-Panama,2021-04-05,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1379229927845810177/photo/1,387580,266754,120826
+Panama,2021-04-05,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1379229927845810177/photo/1,387580,,
+Panama,2021-04-06,Pfizer/BioNTech,https://www.facebook.com/minsapma/videos/814215869178702/,408618,251518,157100
+Panama,2021-04-07,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1379973785332244486,440787,,


### PR DESCRIPTION
Vaccination update against COVID-19 in the Republic of Panama corresponding to April 6 and 7, 2021 by the Ministry of Health. The doses of April 5 are corrected, those of April 6 given in a press conference with its link are confirmed and it is added on the 7th.