### PR TITLE
Vax/Update Cambodia

### DIFF
--- a/public/data/vaccinations/country_data/Cambodia.csv
+++ b/public/data/vaccinations/country_data/Cambodia.csv
@@ -27,3 +27,4 @@ Cambodia,2021-04-04,"Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac",http://www.
 Cambodia,2021-04-05,"Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac",http://www.freshnewsasia.com/index.php/en/,886524,635244,251280
 Cambodia,2021-04-06,"Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac",http://www.freshnewsasia.com/index.php/en/,945715,692569,253146
 Cambodia,2021-04-07,"Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac",http://www.freshnewsasia.com/index.php/en/,1011649,756526,255123
+Cambodia,2021-04-08,"Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac",http://www.freshnewsasia.com/index.php/en/,1071260,813826,257434


### PR DESCRIPTION
Cambodia Covid-19 vaccination update 08-Apr-21:
+ One dose:
- MoH: 615,528
- MoD: 198,298
**- Total one dose: 813,826**

+ Two doses:
- MoH: 142,310
- MoD 115,124
**- Total two doses: 257,434**

**- Total doses administered: 1,071,260**

+Sources:
MoH: http://www.freshnewsasia.com/index.php/en/localnews/192912-2021-04-09-00-57-48.html
MoD: http://www.freshnewsasia.com/index.php/en/localnews/192897-2021-04-08-13-42-00.html