### PR TITLE
Update Chile.csv

### DIFF
--- a/public/data/vaccinations/country_data/Chile.csv
+++ b/public/data/vaccinations/country_data/Chile.csv
@@ -104,3 +104,4 @@ Chile,2021-04-04,"Pfizer/BioNTech, Sinovac",https://www.gob.cl/yomevacuno/,10796
 Chile,2021-04-05,"Pfizer/BioNTech, Sinovac",https://www.gob.cl/yomevacuno/,11078912,7024745,4054167
 Chile,2021-04-06,"Pfizer/BioNTech, Sinovac",https://www.gob.cl/yomevacuno/,11315012,7116055,4198957
 Chile,2021-04-07,"Pfizer/BioNTech, Sinovac",https://www.gob.cl/yomevacuno/,11396072,7144047,4252025
+Chile,2021-04-09,"Pfizer/BioNTech, Sinovac",https://www.gob.cl/yomevacuno/,11777275,7283213,4494062


### PR DESCRIPTION
Vaccination update against COVID-19 in the Republic of Panama corresponding to April 10, 2021 by the Ministry of Health.