### PR TITLE
Update Bolivia.csv

### DIFF
--- a/public/data/vaccinations/country_data/Bolivia.csv
+++ b/public/data/vaccinations/country_data/Bolivia.csv
@@ -44,3 +44,5 @@ Bolivia,2021-04-04,"Oxford/AstraZeneca, Sinopharm/Beijing, Sputnik V",https://tw
 Bolivia,2021-04-05,"Oxford/AstraZeneca, Sinopharm/Beijing, Sputnik V",https://twitter.com/SaludDeportesBo/status/1379264587577622533,339633,215926,123707
 Bolivia,2021-04-06,"Oxford/AstraZeneca, Sinopharm/Beijing, Sputnik V",https://twitter.com/SaludDeportesBo/status/1379615780485074944,357924,229556,128368
 Bolivia,2021-04-07,"Oxford/AstraZeneca, Sinopharm/Beijing, Sputnik V",https://twitter.com/SaludDeportesBo/status/1379981645671960576,378455,245763,132692
+Bolivia,2021-04-08,"Oxford/AstraZeneca, Sinopharm/Beijing, Sputnik V",https://twitter.com/SaludDeportesBo/status/1380343958199537665,400804,263732,137072
+Bolivia,2021-04-09,"Oxford/AstraZeneca, Sinopharm/Beijing, Sputnik V",https://twitter.com/SaludDeportesBo/status/1380701119597404162,423842,282801,141041


### PR DESCRIPTION
Vaccination update against COVID-19 in the Plurinational State of Bolivia corresponding to April 8 and 9, 2021.