### PR TITLE
Vax/Update Cambodia

### DIFF
--- a/public/data/vaccinations/country_data/Cambodia.csv
+++ b/public/data/vaccinations/country_data/Cambodia.csv
@@ -44,3 +44,4 @@ Cambodia,2021-04-05,"Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac",http://www.
 Cambodia,2021-04-06,"Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac",http://www.freshnewsasia.com/index.php/en/,945715,692569,253146
 Cambodia,2021-04-07,"Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac",http://www.freshnewsasia.com/index.php/en/,1011649,756526,255123
 Cambodia,2021-04-08,"Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac",http://www.freshnewsasia.com/index.php/en/,1071260,813826,257434
+Cambodia,2021-04-09,"Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac",http://www.freshnewsasia.com/index.php/en/,1187753,913171,274582


### PR DESCRIPTION
The prime minister of Cambodia, Hun Sen, has ordered the Ministry of Labour and Vocational Training (MLVT) to administer vaccines for factory workers in suburbs around the capital city starting from 07-Apr-21.
Official article: http://www.mlvt.gov.kh/index.php/ឯកសារផ្លូវការ/សេចក្ដីជូនដំណឹង-សេចក្ដីណែនាំ/51-សេចក្ដីជូនដំណឹង-សេចក្ដីណែនាំ/1591-សេចក្តីជូនដំណឹង-លេខ១៤-២១-ស្ដីពីការចាក់វ៉ាក់សាំងកូវីដ-១៩-ស៊ីណូវ៉ាក់-ជូនបងប្អូនកម្មករ-និយោជិតតាមរោងចក្រ-សហគ្រាស-នៅរាជធានីភ្នំពេញ.html

09-Apr-21 Cambodia covid-19 vaccination update:
+ One dose:
- MoH: 678,406
- MoD: 216,903
- MLVT: 17,862
**- Total one dose: 913,171**

+ Two doses:
- MoH: 156,969
- MoD: 117,613
- MLVT: 0
**- Total two doses: 274,582**

**Total vaccines administered: 1,187,753**

+ Sources:
MoH: http://www.freshnewsasia.com/index.php/en/localnews/193098-2021-04-09-16-53-42.html
MoD: http://www.freshnewsasia.com/index.php/en/localnews/193078-2021-04-09-13-33-26.html
MLVT: http://www.freshnewsasia.com/index.php/en/localnews/193090-2021-04-09-15-08-12.html