### PR TITLE
Vax/Update Cambodia

### DIFF
--- a/public/data/vaccinations/country_data/Cambodia.csv
+++ b/public/data/vaccinations/country_data/Cambodia.csv
@@ -44,4 +44,5 @@ Cambodia,2021-04-05,"Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac",http://www.
 Cambodia,2021-04-06,"Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac",http://www.freshnewsasia.com/index.php/en/,945715,692569,253146
 Cambodia,2021-04-07,"Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac",http://www.freshnewsasia.com/index.php/en/,1011649,756526,255123
 Cambodia,2021-04-08,"Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac",http://www.freshnewsasia.com/index.php/en/,1071260,813826,257434
-Cambodia,2021-04-09,"Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac",http://www.freshnewsasia.com/index.php/en/,1187753,913171,274582
+Cambodia,2021-04-09,"Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac",http://www.freshnewsasia.com/index.php/en/,1187753,913171,260864
+Cambodia,2021-04-10,"Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac",http://www.freshnewsasia.com/index.php/en/,1237988,972028,265960


### PR DESCRIPTION
*Revised two doses figure by MoH on 09-Apr-21 due to MoH's calculation error.

Cambodia covid-19 vaccination update for 10-Apr-21:
- Total doses administered: 1,237,988
- One dose: 972,028
- Two doses: 265,960

Sources:
- MoH: http://www.freshnewsasia.com/index.php/en/localnews/193223-2021-04-10-16-38-05.html
- MoD: http://www.freshnewsasia.com/index.php/en/localnews/193209-2021-04-10-13-23-07.html