### PR TITLE
Update Serbia

### DIFF
--- a/public/data/vaccinations/locations.csv
+++ b/public/data/vaccinations/locations.csv
@@ -140,7 +140,7 @@ Sao Tome and Principe,STP,Oxford/AstraZeneca,2021-03-29,Ministry of Health,https
 Saudi Arabia,SAU,"Oxford/AstraZeneca, Pfizer/BioNTech",2021-04-09,Saudi Health Council,https://coronamap.sa
 Scotland,OWID_SCT,"Oxford/AstraZeneca, Pfizer/BioNTech",2021-04-08,Government of the United Kingdom,https://coronavirus.data.gov.uk/details/healthcare
 Senegal,SEN,Sinopharm/Beijing,2021-04-08,Ministry of Health,https://twitter.com/MinisteredelaS1/status/1380102539497107463
-Serbia,SRB,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinopharm/Beijing, Sputnik V",2021-04-09,Government of Serbia,https://www.rts.rs/page/stories/sr/%D0%9A%D0%BE%D1%80%D0%BE%D0%BD%D0%B0%D0%B2%D0%B8%D1%80%D1%83%D1%81/story/3134/koronavirus-u-srbiji/4327119/koronavirus-srbija-podaci-9.-april-2021..html
+Serbia,SRB,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinopharm/Beijing, Sputnik V",2021-04-09,Government of Serbia,https://www.rts.rs/page/stories/sr/%D0%9A%D0%BE%D1%80%D0%BE%D0%BD%D0%B0%D0%B2%D0%B8%D1%80%D1%83%D1%81/story/3134/koronavirus-u-srbiji/4328512/koronavirus-srbija-zarazeni-novi-podaci-10.-april.html
 Seychelles,SYC,"Oxford/AstraZeneca, Sinopharm/Beijing",2021-04-06,Extended Programme for Immunisation,https://www.facebook.com/mohseychellesofficial/photos/pcb.1708499119351212/1708497929351331
 Sierra Leone,SLE,Oxford/AstraZeneca,2021-03-31,Ministry of Health and Sanitation,https://www.facebook.com/mohsict/posts/1364398257254650?__cft__[0]=AZVUsZK074PXnWeL3SKuwHd38CO0CYo3DnAC9ULT_DkxQ7B_IPX_LKMiwKqPDGj2sB0R-fAdtD8t5zCYjOEy-NwuApAV6UgtPLBim5XGbS-Ty5kzZQ4d-IlmhoUJXu5I6prPFqmDBKZBJWuOTQIDpuJg&__tn__=%2CO%2CP-R
 Singapore,SGP,"Moderna, Pfizer/BioNTech",2021-04-06,Ministry of Health,https://www.moh.gov.sg/covid-19


### PR DESCRIPTION
https://www.rts.rs/page/stories/sr/%D0%9A%D0%BE%D1%80%D0%BE%D0%BD%D0%B0%D0%B2%D0%B8%D1%80%D1%83%D1%81/story/3134/koronavirus-u-srbiji/4328512/koronavirus-srbija-zarazeni-novi-podaci-10.-april.html

2.882.854 doses administered
1.166.011 fully vaccinated