### PR TITLE
Vaccination - Cambodia update 11-Apr-21

### DIFF
--- a/public/data/vaccinations/country_data/Cambodia.csv
+++ b/public/data/vaccinations/country_data/Cambodia.csv
@@ -46,3 +46,4 @@ Cambodia,2021-04-07,"Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac",http://www.
 Cambodia,2021-04-08,"Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac",http://www.freshnewsasia.com/index.php/en/,1071260,813826,257434
 Cambodia,2021-04-09,"Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac",http://www.freshnewsasia.com/index.php/en/,1174035,913171,260864
 Cambodia,2021-04-10,"Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac",http://www.freshnewsasia.com/index.php/en/,1237988,972028,265960
+Cambodia,2021-04-11,"Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac",http://www.freshnewsasia.com/index.php/en/,1286585,1018605,267980


### PR DESCRIPTION
Cambodia covid-19 vaccination update 11 April 2021:
- Total doses administered: 1,286,585
- One dose given: 1,018,605
- Two doses given (fully vaccinated): 267,980

+ Sources:
MoH: http://www.freshnewsasia.com/index.php/en/localnews/193301-2021-04-11-15-33-28.html
MoD: http://www.freshnewsasia.com/index.php/en/localnews/193291-2021-04-11-13-26-05.html