### PR TITLE
Cambodia - Vaccination update 12-Apr-21

### DIFF
--- a/public/data/vaccinations/country_data/Cambodia.csv
+++ b/public/data/vaccinations/country_data/Cambodia.csv
@@ -47,3 +47,4 @@ Cambodia,2021-04-08,"Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac",http://www.
 Cambodia,2021-04-09,"Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac",http://www.freshnewsasia.com/index.php/en/,1174035,913171,260864
 Cambodia,2021-04-10,"Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac",http://www.freshnewsasia.com/index.php/en/,1237988,972028,265960
 Cambodia,2021-04-11,"Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac",http://www.freshnewsasia.com/index.php/en/,1286585,1018605,267980
+Cambodia,2021-04-12,"Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac",http://www.freshnewsasia.com/index.php/en/,1371536,1099811,271725


### PR DESCRIPTION
Cambodia covid-19 vaccination update 12 April 2021:
- Total doses administered: 1,371,536
- One dose given: 1,099,811
- Two doses given (fully vaccinated): 271,725

Sources:
MoH: http://www.freshnewsasia.com/index.php/en/localnews/193533-2021-04-12-16-23-12.html
MoD: http://www.freshnewsasia.com/index.php/en/localnews/193511-2021-04-12-14-27-50.html