### PR TITLE
Cambodia - Vaccination update 13 April 2021

### DIFF
--- a/public/data/vaccinations/country_data/Cambodia.csv
+++ b/public/data/vaccinations/country_data/Cambodia.csv
@@ -48,3 +48,4 @@ Cambodia,2021-04-09,"Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac",http://www.
 Cambodia,2021-04-10,"Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac",http://www.freshnewsasia.com/index.php/en/,1237988,972028,265960
 Cambodia,2021-04-11,"Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac",http://www.freshnewsasia.com/index.php/en/,1286585,1018605,267980
 Cambodia,2021-04-12,"Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac",http://www.freshnewsasia.com/index.php/en/,1371536,1099811,271725
+Cambodia,2021-04-13,"Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac",http://www.freshnewsasia.com/index.php/en/,1446457,1170029,276428


### PR DESCRIPTION
Cambodia covid-19 vaccination update 13 April 21:
**- Total doses administered: 1,446,457**
- One dose given: 1,170,029
- Two doses given: 276,428

Sources:
MoH: http://www.freshnewsasia.com/index.php/en/localnews/193815-2021-04-13-14-58-45.html
MoD: http://www.freshnewsasia.com/index.php/en/localnews/193793-2021-04-13-13-22-42.html