### PR TITLE
Update Panama.csv

### DIFF
--- a/public/data/vaccinations/country_data/Panama.csv
+++ b/public/data/vaccinations/country_data/Panama.csv
@@ -78,3 +78,5 @@ Panama,2021-04-08,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1380301588
 Panama,2021-04-09,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1380688588652826625,478146,,
 Panama,2021-04-10,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1381036525102710785/photo/1,490911,,
 Panama,2021-04-11,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1381399460203397121/photo/3,498584,,
+Panama,2021-04-12,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1381779875862880259/photo/1,505005,,
+Panama,2021-04-13,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1382141574864379905/photo/3,518629,350766,167863


### PR DESCRIPTION
Vaccination update against COVID-19 in the Republic of Panama corresponding to April 12 and 13, 2021 reported by the Ministry of Health. There is an error or problem with the information from Panama in “Share of people who received
at least one dose of COVID-19
vaccine, Apr 12, 2021 "which the latest information appears on April 6 with only 5%.