### PR TITLE
Update Bolivia.csv

### DIFF
--- a/public/data/vaccinations/country_data/Bolivia.csv
+++ b/public/data/vaccinations/country_data/Bolivia.csv
@@ -48,3 +48,5 @@ Bolivia,2021-04-08,"Oxford/AstraZeneca, Sinopharm/Beijing, Sputnik V",https://tw
 Bolivia,2021-04-09,"Oxford/AstraZeneca, Sinopharm/Beijing, Sputnik V",https://twitter.com/SaludDeportesBo/status/1380701119597404162,423842,282801,141041
 Bolivia,2021-04-10,"Oxford/AstraZeneca, Sinopharm/Beijing, Sputnik V",https://twitter.com/SaludDeportesBo/status/1381063787567058950,428502,287004,141498
 Bolivia,2021-04-11,"Oxford/AstraZeneca, Sinopharm/Beijing, Sputnik V",https://twitter.com/SaludDeportesBo/status/1381416610955735044,431018,289353,141665
+Bolivia,2021-04-12,"Oxford/AstraZeneca, Sinopharm/Beijing, Sputnik V",https://twitter.com/SaludDeportesBo/status/1381778655450431491,447417,302991,144426
+Bolivia,2021-04-13,"Oxford/AstraZeneca, Sinopharm/Beijing, Sputnik V",https://twitter.com/SaludDeportesBo/status/1382143976992555008,465896,317701,148195


### PR DESCRIPTION
Vaccination update against COVID-19 in the Plurinational State of Bolivia corresponding to April 12 and 13, 2021 reported by the Ministry of Health and Sports.