### PR TITLE
Update testing_data_corrections.R

### DIFF
--- a/scripts/scripts/testing/testing_data_corrections.R
+++ b/scripts/scripts/testing/testing_data_corrections.R
@@ -6,3 +6,7 @@ collated[Country == "Austria" & Date >= "2021-01-01", `Short-term tests per case
 # included cases confirmed without PCR tests (while our data only includes PCR tests)
 collated[Country == "Ecuador" & Date < "2020-09-14", `Short-term positive rate` := NA]
 collated[Country == "Ecuador" & Date < "2020-09-14", `Short-term tests per case` := NA]
+
+# Mauritania: the test definition does not match the case definition (screening tests possibly included in testing figures)
+collated[Country == "Mauritania", `Short-term positive rate` := NA]
+collated[Country == "Mauritania", `Short-term tests per case` := NA]


### PR DESCRIPTION
According to a post (https://fr.ami.mr/Depeche-56446.html) by the Ministry of Information, antigen tests cannot be used to confirm cases of COVID-19, but are used for screening purposes. Since 7 July 2020, the daily situation reports have differentiated between the number of tests performed in the past 24 hours and the number of "diagnostic" tests performed in the past 24 hours. For example, the  11 October 2020 situation report (http://www.sante.gov.mr/wp-content/uploads/2020/10/111020-Mauritanie-Sitrep-COVID-19_FR-.pdf) states: "91 tests performed today including 83 diagnostic tests" (translated). The non-diagnostic tests presumably refer to antigen and antibody screening tests. However, it is unclear if these screening tests are included in the cumulative number of tests performed to date. The case definition therefore may not match the test definition, and so we remove our estimate of the Positive Rate.