### PR TITLE
Cambodia - Vaccination update 14-Apr-21

### DIFF
--- a/public/data/vaccinations/country_data/Cambodia.csv
+++ b/public/data/vaccinations/country_data/Cambodia.csv
@@ -49,3 +49,4 @@ Cambodia,2021-04-10,"Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac",http://www.
 Cambodia,2021-04-11,"Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac",http://www.freshnewsasia.com/index.php/en/,1286585,1018605,267980
 Cambodia,2021-04-12,"Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac",http://www.freshnewsasia.com/index.php/en/,1371536,1099811,271725
 Cambodia,2021-04-13,"Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac",http://www.freshnewsasia.com/index.php/en/,1446457,1170029,276428
+Cambodia,2021-04-14,"Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac",http://www.freshnewsasia.com/index.php/en/,1482123,1203636,278487


### PR DESCRIPTION
Cambodia covid-19 vaccination update 14 April 2021:
- Total doses administered: 1,482,123
- One dose given: 1,203,636
- Two doses given: 278,487

Sources:
MoH: http://www.freshnewsasia.com/index.php/en/localnews/193956-2021-04-14-17-41-15.html
MoD: http://www.freshnewsasia.com/index.php/en/localnews/193934-2021-04-14-13-02-06.html