### PR TITLE
Cambodia - vaccination update 15-Apr-21

### DIFF
--- a/public/data/vaccinations/country_data/Cambodia.csv
+++ b/public/data/vaccinations/country_data/Cambodia.csv
@@ -50,3 +50,4 @@ Cambodia,2021-04-11,"Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac",http://www.
 Cambodia,2021-04-12,"Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac",http://www.freshnewsasia.com/index.php/en/,1371536,1099811,271725
 Cambodia,2021-04-13,"Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac",http://www.freshnewsasia.com/index.php/en/,1446457,1170029,276428
 Cambodia,2021-04-14,"Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac",http://www.freshnewsasia.com/index.php/en/,1482123,1203636,278487
+Cambodia,2021-04-15,"Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac",http://www.freshnewsasia.com/index.php/en/,1508813,1223322,285491


### PR DESCRIPTION
Cambodia covid-19 vaccination update as at 15 April 2021:
**- Total doses administered: 1,508,813**
- One dose given: 1,223,322
- Two doses given: 285,491

Sources:
MoH: http://www.freshnewsasia.com/index.php/en/localnews/194089-2021-04-16-02-08-22.html
MoD: http://www.freshnewsasia.com/index.php/en/localnews/194059-2021-04-15-11-53-22.html