### PR TITLE
Update Macao.csv

### DIFF
--- a/public/data/vaccinations/country_data/Macao.csv
+++ b/public/data/vaccinations/country_data/Macao.csv
@@ -51,3 +51,6 @@ Macao,2021-04-10,"Sinopharm/Beijing, Pfizer/BioNTech",https://www.gov.mo/zh-hant
 Macao,2021-04-11,"Sinopharm/Beijing, Pfizer/BioNTech",https://www.gov.mo/zh-hant/news/372906/,67431,44838,22593
 Macao,2021-04-12,"Sinopharm/Beijing, Pfizer/BioNTech",https://www.gov.mo/zh-hant/news/372985/,69149,45648,23501
 Macao,2021-04-13,"Sinopharm/Beijing, Pfizer/BioNTech",https://www.gov.mo/zh-hant/news/373074/,71196,46732,24464
+Macao,2021-04-14,"Sinopharm/Beijing, Pfizer/BioNTech",https://www.gov.mo/zh-hant/news/373255/,73100,47812,25288
+Macao,2021-04-15,"Sinopharm/Beijing, Pfizer/BioNTech",https://www.gov.mo/zh-hant/news/373374/,75087,48974,26113
+Macao,2021-04-16,"Sinopharm/Beijing, Pfizer/BioNTech",https://www.gov.mo/zh-hant/news/373511/,77236,50184,27052


### PR DESCRIPTION
The Macao official has change their choices of wording in the press release, 
“累計已接種劑數77,236劑，已接種人數共有50,184人，其中已接種1劑有23,132人，已完成接種2劑有27,052人。”
“累計已接種劑數77,236劑” means the total vaccination no.
“已接種人數共有50,184人” means the no. of people vaccinated 
“已完成接種2劑有27,052人” means the no. of people fully vaccinated