### PR TITLE
Cambodia - vaccination update 16-Apr-21

### DIFF
--- a/public/data/vaccinations/country_data/Cambodia.csv
+++ b/public/data/vaccinations/country_data/Cambodia.csv
@@ -51,3 +51,4 @@ Cambodia,2021-04-12,"Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac",http://www.
 Cambodia,2021-04-13,"Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac",http://www.freshnewsasia.com/index.php/en/,1446457,1170029,276428
 Cambodia,2021-04-14,"Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac",http://www.freshnewsasia.com/index.php/en/,1482123,1203636,278487
 Cambodia,2021-04-15,"Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac",http://www.freshnewsasia.com/index.php/en/,1508813,1223322,285491
+Cambodia,2021-04-16,"Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac",http://www.freshnewsasia.com/index.php/en/,1541896,1241947,299949


### PR DESCRIPTION
Cambodia covid-19 vaccination update 16 April 2021:

**- Total doses administered: 1,541,896**
- One dose given: 1,241,947
- Two doses given: 299,949

Sources:
MoH: http://www.freshnewsasia.com/index.php/en/localnews/194216-2021-04-16-15-54-58.html
MoD: http://www.freshnewsasia.com/index.php/en/localnews/194206-2021-04-16-13-58-17.html