### PR TITLE
Cambodia - vaccination update 17-Apr-21

### DIFF
--- a/public/data/vaccinations/country_data/Cambodia.csv
+++ b/public/data/vaccinations/country_data/Cambodia.csv
@@ -52,3 +52,4 @@ Cambodia,2021-04-13,"Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac",http://www.
 Cambodia,2021-04-14,"Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac",http://www.freshnewsasia.com/index.php/en/,1482123,1203636,278487
 Cambodia,2021-04-15,"Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac",http://www.freshnewsasia.com/index.php/en/,1508813,1223322,285491
 Cambodia,2021-04-16,"Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac",http://www.freshnewsasia.com/index.php/en/,1541896,1241947,299949
+Cambodia,2021-04-17,"Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac",http://www.freshnewsasia.com/index.php/en/,1555438,1253531,301907


### PR DESCRIPTION
Cambodia covid-19 vaccination update as at 17 April 2021:
-	Total doses administered: 1,555,438
o	Partially vaccinated: 1,253,531
o	Fully vaccinated: 301,907

Sources:
MoD: http://www.freshnewsasia.com/index.php/en/localnews/194296-2021-04-17-12-30-05.html
MoH: http://www.freshnewsasia.com/index.php/en/localnews/194216-2021-04-16-15-54-58.html (MoH has put covid-19 vaccination on hold for 3 days, from 17-19 April, due to severe covid cases and lockdown recently. Data and sources are brought forward from the latest campaign day, 16 April 2021.)
