### PR TITLE
Update Bolivia.csv

### DIFF
--- a/public/data/vaccinations/country_data/Bolivia.csv
+++ b/public/data/vaccinations/country_data/Bolivia.csv
@@ -53,3 +53,6 @@ Bolivia,2021-04-13,"Oxford/AstraZeneca, Sinopharm/Beijing, Sputnik V",https://tw
 Bolivia,2021-04-14,"Oxford/AstraZeneca, Sinopharm/Beijing, Sputnik V",https://twitter.com/SaludDeportesBo/status/1382519770994597894,486354,333137,153217
 Bolivia,2021-04-15,"Oxford/AstraZeneca, Sinopharm/Beijing, Sputnik V",https://twitter.com/SaludDeportesBo/status/1382887630212333569,507411,348591,158820
 Bolivia,2021-04-16,"Oxford/AstraZeneca, Sinopharm/Beijing, Sputnik V",https://twitter.com/SaludDeportesBo/status/1383225846748516353,530496,365333,165163
+Bolivia,2021-04-17,"Oxford/AstraZeneca, Sinopharm/Beijing, Sputnik V",https://twitter.com/SaludDeportesBo/status/1383668018668965891,536373,370483,165891
+Bolivia,2021-04-18,"Oxford/AstraZeneca, Sinopharm/Beijing, Sputnik V",https://twitter.com/SaludDeportesBo/status/1383956691385868300,539230,373139,166091
+Bolivia,2021-04-19,"Oxford/AstraZeneca, Sinopharm/Beijing, Sputnik V",https://twitter.com/SaludDeportesBo/status/1384319103733731329,557394,385889,171505


### PR DESCRIPTION
Vaccination update against COVID-19 in the Plurinational State of Bolivia corresponding to April 17, 18 and 19, 2021 reported by the Ministry of Health and Sports of Bolivia.