### PR TITLE
VAX: Fix reporting date in Costa Rica

### DIFF
--- a/scripts/scripts/vaccinations/output/Costa Rica.csv
+++ b/scripts/scripts/vaccinations/output/Costa Rica.csv
@@ -19,4 +19,4 @@ Costa Rica,2021-03-24,Pfizer/BioNTech,348037,213404,134633,https://www.ccss.sa.c
 Costa Rica,2021-03-29,Pfizer/BioNTech,384355,224092,160263,https://www.ccss.sa.cr/web/coronavirus/vacunacion
 Costa Rica,2021-04-06,Pfizer/BioNTech,504930,291368,213562,https://www.ccss.sa.cr/web/coronavirus/vacunacion
 Costa Rica,2021-04-12,Pfizer/BioNTech,586799,354291,232508,https://www.ccss.sa.cr/web/coronavirus/vacunacion
-Costa Rica,2021-04-20,Pfizer/BioNTech,698327,450593,247734,https://www.ccss.sa.cr/web/coronavirus/vacunacion
+Costa Rica,2021-04-19,Pfizer/BioNTech,698327,450593,247734,https://www.ccss.sa.cr/web/coronavirus/vacunacion


### PR DESCRIPTION
[Official site](https://www.ccss.sa.cr/web/coronavirus/vacunacion) reports data as of 2021-04-20, but apparently the data corresponds to 2021-04-19 based on [presidency](https://www.presidencia.go.cr/comunicados/2021/04/costa-rica-ya-recibio-mas-de-118-000-vacunas-de-pfizer-biontech/).

xref #1123