### PR TITLE
Updated ToC in vaccination scripts readme

### DIFF
--- a/public/data/vaccinations/country_data/China.csv
+++ b/public/data/vaccinations/country_data/China.csv
@@ -40,3 +40,4 @@ China,2021-04-16,"Sinopharm/Beijing, Sinopharm/Wuhan, Sinovac",http://www.nhc.go
 China,2021-04-17,"Sinopharm/Beijing, Sinopharm/Wuhan, Sinovac",http://www.nhc.gov.cn/xcs/yqjzqk/202104/f024fd41574a4132bd5b007c12b71a17.shtml,189809000,,
 China,2021-04-18,"Sinopharm/Beijing, Sinopharm/Wuhan, Sinovac",http://www.nhc.gov.cn/xcs/yqjzqk/202104/6f2444d14dce4ccda1a53554feaa153a.shtml,192127000,,
 China,2021-04-19,"Sinopharm/Beijing, Sinopharm/Wuhan, Sinovac",http://www.nhc.gov.cn/xcs/yqjzqk/202104/aa7229fe6d6d439aa60c884692cbc202.shtml,195022000,,
+China,2021-04-20,"Sinopharm/Beijing, Sinopharm/Wuhan, Sinovac",http://www.nhc.gov.cn/xcs/yqjzqk/202104/4f3b401243cb4c57a940b6b9902f2bd9.shtml,198965000,,

--- a/scripts/scripts/vaccinations/README.md
+++ b/scripts/scripts/vaccinations/README.md
@@ -7,7 +7,7 @@ automated scripts.
 
 ### Content
 - [Directory content](#directory-content)
-- [Output generated](#output-generated)
+- [Generated files](#generated-files)
 - [Update the data](#update-the-data)
 - [Other functions](#other-functions)
 - [FAQs](#FAQs)


### PR DESCRIPTION
Prior to that PR, the ToC included a reference to a section called "Output generated" that was apparently renamed to "Generated files". Therefore, I updated it to reflect the renaming of the section.
I also updated "China.csv".