### PR TITLE
Update Panama.csv

### DIFF
--- a/public/data/vaccinations/country_data/Panama.csv
+++ b/public/data/vaccinations/country_data/Panama.csv
@@ -56,20 +56,24 @@ Panama,2021-03-27,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1375970370
 Panama,2021-03-28,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1376326017917333507,357431,,
 Panama,2021-03-29,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1376662708737675300,358277,,
 Panama,2021-03-30,Pfizer/BioNTech,https://fb.watch/4zFbSC-ruH/,364079,247539,116540
-Panama,2021-03-31,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1377402299572613121/photo/1,370793,,
-Panama,2021-04-01,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1377778846490054656/photo/2,373491,,
-Panama,2021-04-05,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1379229927845810177/photo/1,387580,,
-Panama,2021-04-06,Pfizer/BioNTech,https://www.facebook.com/minsapma/videos/814215869178702/,408618,251518,157100
-Panama,2021-04-07,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1379973785332244486,440787,,
-Panama,2021-04-08,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1380301588263268352,456929,,
-Panama,2021-04-09,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1380688588652826625,478146,,
-Panama,2021-04-10,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1381036525102710785/photo/1,490911,,
-Panama,2021-04-11,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1381399460203397121/photo/3,498584,,
-Panama,2021-04-12,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1381779875862880259/photo/1,505005,,
-Panama,2021-04-13,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1382141574864379905/photo/3,518629,350766,167863
-Panama,2021-04-14,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1382468563919900672/photo/2,529017,354009,175008
-Panama,2021-04-15,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1382832727108546565/photo/2,550860,,
-Panama,2021-04-16,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1383225885428371456,557510,,
-Panama,2021-04-17,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1383571499060129798/photo/1,560691,,
-Panama,2021-04-18,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1383949793446162432?s=20,564725,,
-Panama,2021-04-19,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1384281960583860233?s=20,565471,,
+Panama,2021-03-31,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1377402299572613121,370793,254253,116540
+Panama,2021-04-01,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1377778846490054656,373491,256951,116540
+Panama,2021-04-05,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1379229927845810177,387580,271040,116540
+Panama,2021-04-06,Pfizer/BioNTech,https://www.facebook.com/minsapma/videos/814215869178702,408618,251518,157100
+Panama,2021-04-07,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1379973785332244486,440787,283687,157100
+Panama,2021-04-08,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1380301588263268352,456929,299829,157100
+Panama,2021-04-09,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1380688588652826625,478146,321046,157100
+Panama,2021-04-10,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1381036525102710785,490911,333811,157100
+Panama,2021-04-11,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1381399460203397121,498584,341484,157100
+Panama,2021-04-12,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1381779875862880259,505005,347895,157110
+Panama,2021-04-13,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1382141574864379905,518629,350766,167863
+Panama,2021-04-14,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1382468563919900672,529017,354009,175008
+Panama,2021-04-15,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1382832727108546565,550860,375823,175028
+Panama,2021-04-16,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1383225885428371456,557510,382476,175034
+Panama,2021-04-17,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1383225885428371456,560691,385633,175058
+Panama,2021-04-18,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1383949793446162432,564725,382289,182436
+Panama,2021-04-19,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1384281960583860233,565471,383015,182456
+Panama,2021-04-20,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1384674823624970242,569267,383961,185309
+Panama,2021-04-21,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1385028828918075394,574212,388325,185887
+
+


### PR DESCRIPTION
Vaccination update against COVID-19 in the Republic of Panama corresponding to March 30 to April 21, 2021.I strongly request that it be approved as I submit it to maintain the integrity of the information on Google and our word in data. The second doses come from the official site https://vacunas.panamasolidario.gob.pa.