### PR TITLE
VAX: Use a smaller source dataset in Czechia

### DIFF
--- a/scripts/scripts/vaccinations/src/vax/batch/czechia.py
+++ b/scripts/scripts/vaccinations/src/vax/batch/czechia.py
@@ -20,7 +20,7 @@ def read(source: str) -> pd.DataFrame:
     return pd.read_csv(source, parse_dates=["datum"])
 
 
-def check_columns(input: pd.DataFrame) -> pd.DataFrame:
+def check_columns(df: pd.DataFrame) -> pd.DataFrame:
     expected = [
         "datum",
         "vakcina",
@@ -31,51 +31,51 @@ def check_columns(input: pd.DataFrame) -> pd.DataFrame:
         "druhych_davek",
         "celkem_davek",
     ]
-    if list(input.columns) != expected:
+    if list(df.columns) != expected:
         raise ValueError(
             "Wrong columns. Was expecting {} and got {}".format(
-                expected, list(input.columns)
+                expected, list(df.columns)
             )
         )
-    return input
+    return df
 
 
-def check_vaccine_names(input: pd.DataFrame) -> pd.DataFrame:
-    unknown_vaccines = set(input.vakcina.unique()).difference(
+def check_vaccine_names(df: pd.DataFrame) -> pd.DataFrame:
+    unknown_vaccines = set(df.vakcina.unique()).difference(
         set(vaccine_mapping.keys())
     )
     if unknown_vaccines:
         raise ValueError("Found unknown vaccines: {}".format(unknown_vaccines))
-    return input
+    return df
 
 
-def translate_vaccine_names(input: pd.DataFrame) -> pd.DataFrame:
-    return input.replace(vaccine_mapping)
+def translate_vaccine_names(df: pd.DataFrame) -> pd.DataFrame:
+    return df.replace(vaccine_mapping)
 
 
-def enrich_source(input: pd.DataFrame) -> pd.DataFrame:
-    return input.assign(source_url="https://onemocneni-aktualne.mzcr.cz/covid-19")
+def enrich_source(df: pd.DataFrame) -> pd.DataFrame:
+    return df.assign(source_url="https://onemocneni-aktualne.mzcr.cz/covid-19")
 
 
-def enrich_location(input: pd.DataFrame) -> pd.DataFrame:
-    return input.assign(location="Czechia")
+def enrich_location(df: pd.DataFrame) -> pd.DataFrame:
+    return df.assign(location="Czechia")
 
 
-def enrich_metadata(input: pd.DataFrame) -> pd.DataFrame:
-    return input.pipe(enrich_location).pipe(enrich_source)
+def enrich_metadata(df: pd.DataFrame) -> pd.DataFrame:
+    return df.pipe(enrich_location).pipe(enrich_source)
 
 
-def base_pipeline(input: pd.DataFrame) -> pd.DataFrame:
+def base_pipeline(df: pd.DataFrame) -> pd.DataFrame:
     return (
-        input.pipe(check_columns)
+        df.pipe(check_columns)
         .pipe(check_vaccine_names)
         .pipe(translate_vaccine_names)
     )
 
 
-def breakdown_per_vaccine(input: pd.DataFrame) -> pd.DataFrame:
+def breakdown_per_vaccine(df: pd.DataFrame) -> pd.DataFrame:
     return (
-        input.groupby(by=["datum", "vakcina"], as_index=False)
+        df.groupby(by=["datum", "vakcina"], as_index=False)
         [["celkem_davek"]].sum()
         .sort_values("datum")
         .assign(
@@ -93,9 +93,9 @@ def breakdown_per_vaccine(input: pd.DataFrame) -> pd.DataFrame:
     )
 
 
-def aggregate_by_date_vaccine(input: pd.DataFrame) -> pd.DataFrame:
+def aggregate_by_date_vaccine(df: pd.DataFrame) -> pd.DataFrame:
     return (
-        input.groupby(by=["datum", "vakcina"])
+        df.groupby(by=["datum", "vakcina"])
         [["prvnich_davek", "druhych_davek"]].sum()
         .reset_index()
         .rename({
@@ -105,20 +105,20 @@ def aggregate_by_date_vaccine(input: pd.DataFrame) -> pd.DataFrame:
     )
 
 
-def infer_one_dose_vaccines(input: pd.DataFrame) -> pd.DataFrame:
-    input.loc[input.vakcina.isin(one_dose_vaccines), 2] = input[1]
-    return input
+def infer_one_dose_vaccines(df: pd.DataFrame) -> pd.DataFrame:
+    df.loc[df.vakcina.isin(one_dose_vaccines), 2] = df[1]
+    return df
 
 
-def infer_total_vaccinations(input: pd.DataFrame) -> pd.DataFrame:
-    input.loc[input.vakcina.isin(one_dose_vaccines), "total_vaccinations"] = input[1].fillna(0)
-    input.loc[-input.vakcina.isin(one_dose_vaccines), "total_vaccinations"] = input[1].fillna(0) + input[2].fillna(0)
-    return input
+def infer_total_vaccinations(df: pd.DataFrame) -> pd.DataFrame:
+    df.loc[df.vakcina.isin(one_dose_vaccines), "total_vaccinations"] = df[1].fillna(0)
+    df.loc[-df.vakcina.isin(one_dose_vaccines), "total_vaccinations"] = df[1].fillna(0) + df[2].fillna(0)
+    return df
 
 
-def aggregate_by_date(input: pd.DataFrame) -> pd.DataFrame:
+def aggregate_by_date(df: pd.DataFrame) -> pd.DataFrame:
     return (
-        input.groupby(by="datum")
+        df.groupby(by="datum")
         .agg(
             vaccine=("vakcina", lambda x: ", ".join(sorted(set(x)))),
             people_vaccinated=(1, "sum"),  # 1 means 1st dose
@@ -129,8 +129,8 @@ def aggregate_by_date(input: pd.DataFrame) -> pd.DataFrame:
     )
 
 
-def check_first_date(input: pd.DataFrame) -> pd.DataFrame:
-    first_date = input.date.min()
+def check_first_date(df: pd.DataFrame) -> pd.DataFrame:
+    first_date = df.date.min()
     expected = "2020-12-27"
     if first_date != expected:
         raise ValueError(
@@ -138,21 +138,21 @@ def check_first_date(input: pd.DataFrame) -> pd.DataFrame:
                 expected, first_date
             )
         )
-    return input
+    return df
 
 
-def translate_columns(input: pd.DataFrame) -> pd.DataFrame:
-    return input.rename(columns={"datum": "date"})
+def translate_columns(df: pd.DataFrame) -> pd.DataFrame:
+    return df.rename(columns={"datum": "date"})
 
 
-def format_date(input: pd.DataFrame) -> pd.DataFrame:
-    return input.assign(date=input.date.astype(str).str.slice(0, 10))
+def format_date(df: pd.DataFrame) -> pd.DataFrame:
+    return df.assign(date=df.date.astype(str).str.slice(0, 10))
 
 
-def enrich_cumulated_sums(input: pd.DataFrame) -> pd.DataFrame:
-    return input.sort_values(by="date").assign(
+def enrich_cumulated_sums(df: pd.DataFrame) -> pd.DataFrame:
+    return df.sort_values(by="date").assign(
         **{
-            col: input[col].cumsum().astype(int)
+            col: df[col].cumsum().astype(int)
             for col in [
                 "total_vaccinations",
                 "people_vaccinated",
@@ -162,9 +162,9 @@ def enrich_cumulated_sums(input: pd.DataFrame) -> pd.DataFrame:
     )
 
 
-def global_pipeline(input: pd.DataFrame) -> pd.DataFrame:
+def global_pipeline(df: pd.DataFrame) -> pd.DataFrame:
     return (
-        input.pipe(aggregate_by_date_vaccine)
+        df.pipe(aggregate_by_date_vaccine)
         .pipe(infer_one_dose_vaccines)
         .pipe(infer_total_vaccinations)
         .pipe(aggregate_by_date)


### PR DESCRIPTION
The Czech ministry has un-deprecated the region-based vaccination dataset, so we can use that one instead of the line-per-person one. This leads to a 100x decrease in bandwidth without losing any data necessary for our purposes.

```
output $ curl -I https://onemocneni-aktualne.mzcr.cz/api/v2/covid-19/ockovaci-mista.csv
...
content-length: 282840066
content-type: text/csv; charset=utf-8

output $ curl -I https://onemocneni-aktualne.mzcr.cz/api/v2/covid-19/ockovani.csv
...
content-length: 2366168
content-type: text/csv; charset=utf-8
```

The smaller dataset has a slightly different schema - the dose information is in columns, not rows, so we don't need to unstack. We also cannot `.size()` to get the total number of vaccines administered, we need to sum over `celkem_davek` (~total doses).

I verified the output using the current master and with my patch and got byte-for-byte identical results.

```
output $ shasum *.csv
d81a97c4870f5e6581521e49f9025083e48b9000  Czechia-master.csv
d81a97c4870f5e6581521e49f9025083e48b9000  Czechia.csv
output $ shasum by_manufacturer/*.csv
be39587f209f74e7b632d2af77d2c2d1ab35efd3  by_manufacturer/Czechia-master.csv
be39587f209f74e7b632d2af77d2c2d1ab35efd3  by_manufacturer/Czechia.csv
```