### PR TITLE
Update Panama.csv

### DIFF
--- a/public/data/vaccinations/country_data/Panama.csv
+++ b/public/data/vaccinations/country_data/Panama.csv
@@ -70,11 +70,12 @@ Panama,2021-04-13,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1382141574
 Panama,2021-04-14,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1382468563919900672,529017,354009,175008
 Panama,2021-04-15,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1382832727108546565,550860,375832,175028
 Panama,2021-04-16,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1383225885428371456,557510,382476,175034
-Panama,2021-04-17,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1383571499060129798,560691,,179068
-Panama,2021-04-18,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1383949793446162432,564725,,182436
-Panama,2021-04-19,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1384281960583860233,565471,,182456
-Panama,2021-04-20,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1384674823624970242,569267,,185309
+Panama,2021-04-17,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1383571499060129798,560691,381623,179068
+Panama,2021-04-18,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1383949793446162432,564725,382289,182436
+Panama,2021-04-19,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1384281960583860233,565471,383015,182456
+Panama,2021-04-20,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1384674823624970242,569267,383958,185309
 Panama,2021-04-21,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1385028828918075394,574212,388325,185887
 Panama,2021-04-22,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1385372295603044356,590703,403293,187410
 Panama,2021-04-23,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1385734678951440388,595807,408266,187541
 Panama,2021-04-24,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1386097203106697216,608957,421295,187662
+Panama,2021-04-25,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1386468166671519744,619190,431459,187731


### PR DESCRIPTION
Update of the vaccination against COVID-19 in the Republic of Panama corresponding to April 25, 2021 reported by the Ministry of Health and the Vacunometer of the National Government Innovation Authority (AIG)