### PR TITLE
Update Panama.csv

### DIFF
--- a/public/data/vaccinations/country_data/Panama.csv
+++ b/public/data/vaccinations/country_data/Panama.csv
@@ -1,79 +1,81 @@
-location,date,vaccine,source_url,total_vaccinations,people_vaccinated,people_fully_vaccinated
-Panama,2021-01-19,Pfizer/BioNTech,https://twitter.com/EstrellaOnline/status/1362232004868194312,0,,
-Panama,2021-01-20,Pfizer/BioNTech,https://twitter.com/EstrellaOnline/status/1362232004868194312,641,,
-Panama,2021-01-21,Pfizer/BioNTech,https://twitter.com/EstrellaOnline/status/1362232004868194312,2728,,
-Panama,2021-01-22,Pfizer/BioNTech,https://twitter.com/EstrellaOnline/status/1362232004868194312,5081,,
-Panama,2021-01-23,Pfizer/BioNTech,https://twitter.com/EstrellaOnline/status/1362232004868194312,5594,,
-Panama,2021-01-24,Pfizer/BioNTech,https://twitter.com/EstrellaOnline/status/1362232004868194312,6420,,
-Panama,2021-01-25,Pfizer/BioNTech,https://twitter.com/EstrellaOnline/status/1362232004868194312,6597,,
-Panama,2021-01-26,Pfizer/BioNTech,https://twitter.com/EstrellaOnline/status/1362232004868194312,7497,,
-Panama,2021-01-27,Pfizer/BioNTech,https://twitter.com/EstrellaOnline/status/1362232004868194312,8546,,
-Panama,2021-01-28,Pfizer/BioNTech,https://twitter.com/EstrellaOnline/status/1362232004868194312,8723,,
-Panama,2021-01-29,Pfizer/BioNTech,https://twitter.com/EstrellaOnline/status/1362232004868194312,8772,,
-Panama,2021-02-01,Pfizer/BioNTech,https://twitter.com/EstrellaOnline/status/1362232004868194312,10549,,
-Panama,2021-02-02,Pfizer/BioNTech,https://twitter.com/EstrellaOnline/status/1362232004868194312,12013,,
-Panama,2021-02-03,Pfizer/BioNTech,https://twitter.com/EstrellaOnline/status/1362232004868194312,12362,,
-Panama,2021-02-04,Pfizer/BioNTech,https://twitter.com/EstrellaOnline/status/1362232004868194312,12428,,
-Panama,2021-02-05,Pfizer/BioNTech,https://twitter.com/EstrellaOnline/status/1362232004868194312,12441,,
-Panama,2021-02-09,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1359303504859381760,12806,,
-Panama,2021-02-18,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1362557418790617090,30776,27191,3575
-Panama,2021-02-19,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1362933407471255556,40830,,
-Panama,2021-02-20,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1363278482596388864,45535,,
-Panama,2021-02-21,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1363635393103597569,45535,,
-Panama,2021-02-22,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1364009616124878848,61168,,
-Panama,2021-02-23,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1364406068848263168,64636,,
-Panama,2021-02-24,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1364744967843962882,79989,,
-Panama,2021-02-25,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1365092686705930241,89419,,
-Panama,2021-02-26,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1365468967503089665,106667,,
-Panama,2021-02-27,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1365813317542031363,114529,,
-Panama,2021-02-28,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1366177026168791046,119176,,
-Panama,2021-03-01,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1366559904119414785,122189,,
-Panama,2021-03-02,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1366920535129657348,132610,,
-Panama,2021-03-03,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1367254075000119297,136343,,
-Panama,2021-03-04,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1367614807063601154,150411,,
-Panama,2021-03-05,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1367995799452409856,166931,,
-Panama,2021-03-06,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1368360967390822403,194715,,
-Panama,2021-03-07,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1368733547956219907,208415,,
-Panama,2021-03-08,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1369072778230501376,211751,,
-Panama,2021-03-09,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1369457216869306371,214492,,
-Panama,2021-03-10,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1369826724284923914,224765,,
-Panama,2021-03-11,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1370185311289016326,233365,,
-Panama,2021-03-12,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1370521869917560832,245177,,
-Panama,2021-03-13,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1370898588067315715,252313,,
-Panama,2021-03-14,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1371267700576677892,253800,,
-Panama,2021-03-15,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1371632651845664769,259843,,
-Panama,2021-03-16,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1371991871925460992,266298,,
-Panama,2021-03-18,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1372715275716558855,287086,,
-Panama,2021-03-19,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1373089053965488130,297165,,
-Panama,2021-03-20,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1373457164694654977,309324,,
-Panama,2021-03-21,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1373802119959023621,309660,,
-Panama,2021-03-22,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1374158652534362116,310108,,
-Panama,2021-03-23,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1374546941422501890,312761,,
-Panama,2021-03-24,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1374858925162520577,320079,,
-Panama,2021-03-25,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1375225055714623488,329822,,
-Panama,2021-03-26,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1375583976727977985,342716,,
-Panama,2021-03-27,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1375970370679930880,352876,,
-Panama,2021-03-28,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1376326017917333507,357431,,
-Panama,2021-03-29,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1376662708737675300,358277,,
-Panama,2021-03-30,Pfizer/BioNTech,https://fb.watch/4zFbSC-ruH/,364079,247539,116540
-Panama,2021-03-31,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1377402299572613121,370793,,
-Panama,2021-04-01,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1377778846490054656,373491,,
-Panama,2021-04-05,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1379229927845810177,387580,,
-Panama,2021-04-06,Pfizer/BioNTech,https://www.facebook.com/minsapma/videos/814215869178702/,408618,251518,157100
-Panama,2021-04-07,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1379973785332244486,440787,,
-Panama,2021-04-08,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1380301588263268352,456929,,
-Panama,2021-04-09,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1380688588652826625,478146,,
-Panama,2021-04-10,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1381036525102710785,490911,,
-Panama,2021-04-11,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1381399460203397121,498584,,
-Panama,2021-04-12,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1381779875862880259,505005,,
-Panama,2021-04-13,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1382141574864379905,518629,350766,167863
-Panama,2021-04-14,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1382468563919900672,529017,354009,175008
-Panama,2021-04-15,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1382832727108546565,550860,375832,175028
-Panama,2021-04-16,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1383225885428371456,557510,382476,175034
-Panama,2021-04-19,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1384281960583860233,565471,383015,182456
-Panama,2021-04-20,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1384674823624970242,569267,383958,185309
-Panama,2021-04-21,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1385028828918075394,574212,388325,185887
-Panama,2021-04-22,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1385372295603044356,590703,403293,187410
-Panama,2021-04-23,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1385734678951440388,595807,408266,187541
-Panama,2021-04-24,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1386097203106697216,608957,421295,187662
-Panama,2021-04-25,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1386468166671519744,619190,431459,187731
+Panama,2021-01-20,Pfizer/BioNTech,https://twitter.com/EstrellaOnline/status/1362232004868194312,641,641,0
+Panama,2021-01-21,Pfizer/BioNTech,https://twitter.com/EstrellaOnline/status/1362232004868194312,2728,2728,0
+Panama,2021-01-22,Pfizer/BioNTech,https://twitter.com/EstrellaOnline/status/1362232004868194312,5081,5081,0
+Panama,2021-01-23,Pfizer/BioNTech,https://twitter.com/EstrellaOnline/status/1362232004868194312,5594,5594,0
+Panama,2021-01-24,Pfizer/BioNTech,https://twitter.com/EstrellaOnline/status/1362232004868194312,6420,6420,0
+Panama,2021-01-25,Pfizer/BioNTech,https://twitter.com/EstrellaOnline/status/1362232004868194312,6597,6597,0
+Panama,2021-01-26,Pfizer/BioNTech,https://twitter.com/EstrellaOnline/status/1362232004868194312,7497,7497,0
+Panama,2021-01-27,Pfizer/BioNTech,https://twitter.com/EstrellaOnline/status/1362232004868194312,8546,8546,0
+Panama,2021-01-28,Pfizer/BioNTech,https://twitter.com/EstrellaOnline/status/1362232004868194312,8723,8723,0
+Panama,2021-01-29,Pfizer/BioNTech,https://twitter.com/EstrellaOnline/status/1362232004868194312,8772,8772,0
+Panama,2021-02-01,Pfizer/BioNTech,https://twitter.com/EstrellaOnline/status/1362232004868194312,10549,10549,0
+Panama,2021-02-02,Pfizer/BioNTech,https://twitter.com/EstrellaOnline/status/1362232004868194312,12013,12013,0
+Panama,2021-02-03,Pfizer/BioNTech,https://twitter.com/EstrellaOnline/status/1362232004868194312,12362,12362,0
+Panama,2021-02-04,Pfizer/BioNTech,https://twitter.com/EstrellaOnline/status/1362232004868194312,12428,12428,0
+Panama,2021-02-05,Pfizer/BioNTech,https://twitter.com/EstrellaOnline/status/1362232004868194312,12441,12441,0
+Panama,2021-02-09,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1359303504859381760,12806,12806,0
+Panama,2021-02-18,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1362557418790617090,30776,28549,2227
+Panama,2021-02-19,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1362933407471255556,40830,38262,2568
+Panama,2021-02-20,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1363278482596388864,45535,42867,2668
+Panama,2021-02-21,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1363635393103597569,47848,45014,2834
+Panama,2021-02-22,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1364009616124878848,61168,57896,3272
+Panama,2021-02-23,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1364406068848263168,64636,61104,3534
+Panama,2021-02-24,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1364744967843962882,79989,74711,5278
+Panama,2021-02-25,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1365092686705930241,89419,83733,5686
+Panama,2021-02-26,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1365468967503089665,106667,100819,5848
+Panama,2021-02-27,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1365813317542031363,114529,108675,5854
+Panama,2021-02-28,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1366177026168791046,119176,113320,5856
+Panama,2021-03-01,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1366559904119414785,122189,116326,5863
+Panama,2021-03-02,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1366920535129657348,132610,126732,5878
+Panama,2021-03-03,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1367254075000119297,136343,130462,5881
+Panama,2021-03-04,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1367614807063601154,150411,144529,5882
+Panama,2021-03-05,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1367995799452409856,166931,161039,5892
+Panama,2021-03-06,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1368360967390822403,194715,191140,5892
+Panama,2021-03-07,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1368733547956219907,208415,202522,5893
+Panama,2021-03-08,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1369072778230501376,211751,205850,5901
+Panama,2021-03-09,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1369457216869306371,214492,208590,5902
+Panama,2021-03-10,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1369826724284923914,224765,218861,5904
+Panama,2021-03-11,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1370185311289016326,233365,227461,5904
+Panama,2021-03-12,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1370521869917560832,245177,239273,5904
+Panama,2021-03-13,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1370898588067315715,252313,246409,5904
+Panama,2021-03-14,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1371267700576677892,253800,247896,5904
+Panama,2021-03-15,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1371632651845664769,259843,245915,13928
+Panama,2021-03-16,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1371991871925460992,266298,243243,23056
+Panama,2021-03-18,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1372715275716558855,287086,235570,51516
+Panama,2021-03-19,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1373089053965488130,297165,238485,58680
+Panama,2021-03-20,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1373457164694654977,309324,248644,60680
+Panama,2021-03-21,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1373802119959023621,309660,248698,60962
+Panama,2021-03-22,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1374158652534362116,310108,247188,62920
+Panama,2021-03-23,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1374546941422501890,312761,246718,66043
+Panama,2021-03-24,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1374858925162520577,320079,240361,79718
+Panama,2021-03-25,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1375225055714623488,329822,238228,91594
+Panama,2021-03-26,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1375583976727977985,342716,243926,98790
+Panama,2021-03-27,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1375970370679930880,352876,251650,101226
+Panama,2021-03-28,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1376326017917333507,357431,255881,101550
+Panama,2021-03-29,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1376662708737675300,358277,256704,101577
+Panama,2021-03-30,Pfizer/BioNTech,https://fb.watch/4zFbSC-ruH/,364079,262396,101683
+Panama,2021-03-31,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1377402299572613121,370793,262090,101703
+Panama,2021-04-01,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1377778846490054656,373491,269072,101722
+Panama,2021-04-05,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1379229927845810177,387580,269747,117833
+Panama,2021-04-06,Pfizer/BioNTech,https://www.facebook.com/minsapma/videos/814215869178702,408618,276374,132244
+Panama,2021-04-07,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1379973785332244486,440787,300804,139983
+Panama,2021-04-08,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1380301588263268352,456929,311480,145449
+Panama,2021-04-09,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1380688588652826625,478146,332630,145516
+Panama,2021-04-10,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1381036525102710785,490911,345248,145663
+Panama,2021-04-11,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1381399460203397121,498584,352903,145691
+Panama,2021-04-12,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1381779875862880259,505005,345894,159111
+Panama,2021-04-13,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1382141574864379905,518629,349033,169596
+Panama,2021-04-14,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1382468563919900672,529017,352276,176741
+Panama,2021-04-15,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1382832727108546565,550860,368217,182643
+Panama,2021-04-16,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1383225885428371456,557510,374250,183260
+Panama,2021-04-17,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1383225885428371456,560691,377215,183476
+Panama,2021-04-18,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1383949793446162432,564725,380939,183786
+Panama,2021-04-19,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1384281960583860233,565471,381070,184401
+Panama,2021-04-20,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1384674823624970242,569267,383997,185270
+Panama,2021-04-21,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1385028828918075394,574212,388362,185850
+Panama,2021-04-22,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1385372295603044356,590703,403926,186777
+Panama,2021-04-23,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1385734678951440388,595807,408366,187441
+Panama,2021-04-24,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1386097203106697216,608957,421297,187660
+Panama,2021-04-25,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1386468166671519744,619190,431461,187729
+Panama,2021-04-26,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1386817108328304642,622720,434695,188025
+Panama,2021-04-27,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1387216977845002243,640507,452242,188265


### PR DESCRIPTION
Complete update of the vaccination process against COVID-19 in the Republic of Panama from January 20 to April 27.The information of the second dose that appears in the vaccine meter historically from the day February 18. In order to verify this information you must enter the vaccinometer page https://vacunas.panamasolidario.gob.pa/vacunometro/, In the left tab, the calendar will appear which shows the number of doses supplied that day in a broken down manner, for which you must add one by one. I appreciate very much that the information is published as it is presented in full integrity. Thank you very much and good day.