### PR TITLE
VAX: Update NL pipeline

### DIFF
--- a/scripts/scripts/vaccinations/output/Netherlands.csv
+++ b/scripts/scripts/vaccinations/output/Netherlands.csv
@@ -1,20 +1,20 @@
-date,total_vaccinations,people_vaccinated,people_fully_vaccinated,source_url,location,vaccine
-2021-01-17,77000,77000,0,https://www.rivm.nl/covid-19-vaccinatie/wekelijkse-update-deelname-covid-19-vaccinatie-in-nederland,Netherlands,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech"
-2021-01-24,146612,146612,0,https://www.rivm.nl/covid-19-vaccinatie/wekelijkse-update-deelname-covid-19-vaccinatie-in-nederland,Netherlands,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech"
-2021-01-31,343526,327834,15692,https://www.rivm.nl/covid-19-vaccinatie/wekelijkse-update-deelname-covid-19-vaccinatie-in-nederland,Netherlands,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech"
-2021-02-07,571145,504736,66409,https://www.rivm.nl/covid-19-vaccinatie/wekelijkse-update-deelname-covid-19-vaccinatie-in-nederland,Netherlands,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech"
-2021-02-14,783438,628993,154445,https://www.rivm.nl/covid-19-vaccinatie/wekelijkse-update-deelname-covid-19-vaccinatie-in-nederland,Netherlands,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech"
-2021-02-21,1014039,795326,218713,https://www.rivm.nl/covid-19-vaccinatie/wekelijkse-update-deelname-covid-19-vaccinatie-in-nederland,Netherlands,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech"
-2021-02-28,1336428,1004757,331671,https://www.rivm.nl/covid-19-vaccinatie/wekelijkse-update-deelname-covid-19-vaccinatie-in-nederland,Netherlands,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech"
-2021-03-07,1619839,1207904,411935,https://www.rivm.nl/covid-19-vaccinatie/cijfers-vaccinatieprogramma,Netherlands,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech"
-2021-03-14,1887726,1394603,493123,https://www.rivm.nl/covid-19-vaccinatie/cijfers-vaccinatieprogramma,Netherlands,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech"
-2021-03-21,2097980,1492489,605491,https://www.rivm.nl/covid-19-vaccinatie/cijfers-vaccinatieprogramma,Netherlands,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech"
-2021-03-28,2378552,1688490,690062,https://www.rivm.nl/covid-19-vaccinatie/cijfers-vaccinatieprogramma,Netherlands,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech"
-2021-04-04,2863986,2057562,806424,https://www.rivm.nl/covid-19-vaccinatie/cijfers-vaccinatieprogramma,Netherlands,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech"
-2021-04-11,3783912,2957777,826135,https://www.rivm.nl/covid-19-vaccinatie/cijfers-vaccinatieprogramma,Netherlands,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech"
-2021-04-18,4578432,3635235,943197,https://www.rivm.nl/covid-19-vaccinatie/cijfers-vaccinatieprogramma,Netherlands,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech"
-2021-04-21,4873624,,,https://coronadashboard.government.nl/landelijk/vaccinaties,Netherlands,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech"
-2021-04-22,4952724,,,https://coronadashboard.government.nl/landelijk/vaccinaties,Netherlands,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech"
-2021-04-25,4991803,3880412,1111391,https://www.rivm.nl/covid-19-vaccinatie/cijfers-vaccinatieprogramma,Netherlands,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech"
-2021-04-27,5176010,,,https://coronadashboard.government.nl/landelijk/vaccinaties,Netherlands,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech"
-2021-04-28,5265860,,,https://coronadashboard.government.nl/landelijk/vaccinaties,Netherlands,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech"
+date,total_vaccinations,people_vaccinated,source_url,location,vaccine,people_fully_vaccinated
+2021-01-17,77000,77000,https://www.rivm.nl/covid-19-vaccinatie/wekelijkse-update-deelname-covid-19-vaccinatie-in-nederland,Netherlands,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",0
+2021-01-24,146612,146612,https://www.rivm.nl/covid-19-vaccinatie/wekelijkse-update-deelname-covid-19-vaccinatie-in-nederland,Netherlands,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",0
+2021-01-31,343526,327834,https://www.rivm.nl/covid-19-vaccinatie/wekelijkse-update-deelname-covid-19-vaccinatie-in-nederland,Netherlands,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",15692
+2021-02-07,571145,504736,https://www.rivm.nl/covid-19-vaccinatie/wekelijkse-update-deelname-covid-19-vaccinatie-in-nederland,Netherlands,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",66409
+2021-02-14,783438,628993,https://www.rivm.nl/covid-19-vaccinatie/wekelijkse-update-deelname-covid-19-vaccinatie-in-nederland,Netherlands,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",154445
+2021-02-21,1014039,795326,https://www.rivm.nl/covid-19-vaccinatie/wekelijkse-update-deelname-covid-19-vaccinatie-in-nederland,Netherlands,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",218713
+2021-02-28,1336428,1004757,https://www.rivm.nl/covid-19-vaccinatie/wekelijkse-update-deelname-covid-19-vaccinatie-in-nederland,Netherlands,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",331671
+2021-03-07,1619839,1207904,https://www.rivm.nl/covid-19-vaccinatie/cijfers-vaccinatieprogramma,Netherlands,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",411935
+2021-03-14,1887726,1394603,https://www.rivm.nl/covid-19-vaccinatie/cijfers-vaccinatieprogramma,Netherlands,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",493123
+2021-03-21,2097980,1492489,https://www.rivm.nl/covid-19-vaccinatie/cijfers-vaccinatieprogramma,Netherlands,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",605491
+2021-03-28,2378552,1688490,https://www.rivm.nl/covid-19-vaccinatie/cijfers-vaccinatieprogramma,Netherlands,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",690062
+2021-04-04,2863986,2057562,https://www.rivm.nl/covid-19-vaccinatie/cijfers-vaccinatieprogramma,Netherlands,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",806424
+2021-04-11,3783912,2957777,https://www.rivm.nl/covid-19-vaccinatie/cijfers-vaccinatieprogramma,Netherlands,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",826135
+2021-04-18,4578432,3635235,https://www.rivm.nl/covid-19-vaccinatie/cijfers-vaccinatieprogramma,Netherlands,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",943197
+2021-04-21,4873624,,https://coronadashboard.government.nl/landelijk/vaccinaties,Netherlands,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",
+2021-04-22,4952724,,https://coronadashboard.government.nl/landelijk/vaccinaties,Netherlands,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",
+2021-04-25,4991803,3880412,https://www.rivm.nl/covid-19-vaccinatie/cijfers-vaccinatieprogramma,Netherlands,"Johnson&Johnson, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",
+2021-04-27,5176010,,https://coronadashboard.government.nl/landelijk/vaccinaties,Netherlands,"Johnson&Johnson, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",
+2021-04-28,5265860,,https://coronadashboard.government.nl/landelijk/vaccinaties,Netherlands,"Johnson&Johnson, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",


### PR DESCRIPTION
- Only report NL weekly to avoid data inconsistencies
- Add J&J
- Stop reporting `people_fully_vaccinated` as the sum of `total_vaccinations` and `people_vaccinated` as it may no longer be valid b/c of J&J addition.