### PR TITLE
Update Panama.csv

### DIFF
--- a/public/data/vaccinations/country_data/Panama.csv
+++ b/public/data/vaccinations/country_data/Panama.csv
@@ -55,14 +55,16 @@ Panama,2021-04-13,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1382141574
 Panama,2021-04-14,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1382468563919900672,529017,352276,176741
 Panama,2021-04-15,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1382832727108546565,550860,368217,182643
 Panama,2021-04-16,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1383225885428371456,557510,374250,183260
-Panama,2021-04-17,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1383225885428371456,560691,377215,183476
-Panama,2021-04-18,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1383949793446162432,564725,380939,183786
-Panama,2021-04-19,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1384281960583860233,565471,381070,184401
-Panama,2021-04-20,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1384674823624970242,569267,383997,185270
-Panama,2021-04-21,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1385028828918075394,574212,388362,185850
+Panama,2021-04-17,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1383225885428371456,560691,377215,183476
+Panama,2021-04-18,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1383949793446162432,564725,380939,183786
+Panama,2021-04-19,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1384281960583860233,565471,381070,184401
+Panama,2021-04-20,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1384674823624970242,569267,383997,185270
+Panama,2021-04-21,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1385028828918075394,574212,388362,185850
 Panama,2021-04-22,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1385372295603044356,590703,403926,186777
 Panama,2021-04-23,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1385734678951440388,595807,408366,187441
 Panama,2021-04-24,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1386097203106697216,608957,421297,187660
 Panama,2021-04-25,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1386468166671519744,619190,431461,187729
 Panama,2021-04-26,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1386817108328304642,622720,434695,188025
 Panama,2021-04-27,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1387216977845002243,640507,452242,188265
+Panama,2021-04-28,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1387585701131264000,643939,454723,189216
+Panama,2021-04-29,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1387935992707964931,672159,482089,190070


### PR DESCRIPTION
Vaccination update against COVID-19 in the Republic of Panama corresponding to April 28 and 29 reported by the Ministry of Health of Panama. The information from Oxford / AstraZeneca is corrected because although it is true that they arrived in the country on April 17, they were not applied until April 22 when Vice President José Gabriel Carrizo was the first to participate in the voluntary vaccination program with that specific vaccine.