### PR TITLE
Update Panama.csv

### DIFF
--- a/public/data/vaccinations/country_data/Panama.csv
+++ b/public/data/vaccinations/country_data/Panama.csv
@@ -68,4 +68,5 @@ Panama,2021-04-26,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINS
 Panama,2021-04-27,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1387216977845002243,640507,452242,188265
 Panama,2021-04-28,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1387585701131264000,643939,453873,190066
 Panama,2021-04-29,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1387935992707964931,672159,482089,190070
-Panama,2021-04-30,"Pfizer/BioNTech, Oxford/AstraZeneca",http://minsa.gob.pa/noticia/comunicado-ndeg-430,672846,,
+Panama,2021-04-30,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1388268461294563338,672846,482065,190781
+Panama,2021-05-02,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1389025402946035712,687653,496449,191204


### PR DESCRIPTION
Vaccination update against COVID-19 in the Republic of Panama corresponding to April 30 and May 2, 2021 reported by the Ministry of Health