### PR TITLE
Update Panama.csv

### DIFF
--- a/public/data/vaccinations/country_data/Panama.csv
+++ b/public/data/vaccinations/country_data/Panama.csv
@@ -68,5 +68,6 @@ Panama,2021-04-26,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINS
 Panama,2021-04-27,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1387216977845002243,640507,452242,188265
 Panama,2021-04-28,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1387585701131264000,643939,453873,190066
 Panama,2021-04-29,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1387935992707964931,672159,482089,190070
-Panama,2021-04-30,"Pfizer/BioNTech, Oxford/AstraZeneca",http://minsa.gob.pa/noticia/comunicado-ndeg-430,672846,,
-Panama,2021-05-01,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1389025402946035712,687653,496449,191204
+Panama,2021-04-30,"Pfizer/BioNTech, Oxford/AstraZeneca",http://minsa.gob.pa/noticia/comunicado-ndeg-430,672846,482065,190781
+Panama,2021-05-02,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1389025402946035712,687653,496449,191204
+Panama,2021-05-03,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1389360276970131456,692764,501055,191709


### PR DESCRIPTION
Vaccination update against COVID-19 in the Republic of Panama corresponding to April 30 and May 2 and 3. On the 30th, the data of the second dose of Vacunometer were added, On May 1 it was not reported and on May 2 and 3 it was reported so it is updated.