### PR TITLE
Update Panama.csv

### DIFF
--- a/public/data/vaccinations/country_data/Panama.csv
+++ b/public/data/vaccinations/country_data/Panama.csv
@@ -71,3 +71,4 @@ Panama,2021-04-29,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINS
 Panama,2021-04-30,"Pfizer/BioNTech, Oxford/AstraZeneca",http://minsa.gob.pa/noticia/comunicado-ndeg-430,672846,,190781
 Panama,2021-05-02,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1389025402946035712,687653,496449,191204
 Panama,2021-05-03,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1389360276970131456,692764,501055,191709
+Panama,2021-05-04,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1389744278679826434,695783,501055,192016


### PR DESCRIPTION
Vaccination update against COVID-19 in the Republic of Panama corresponding to May 4 reported by the Ministry of Health. Today it was confirmed in a press conference that the vaccinometer will be gradually updated until the middle of the month, yielding the real and adequate values.