### PR TITLE
Update Vietnam.csv

### DIFF
--- a/public/data/vaccinations/country_data/Vietnam.csv
+++ b/public/data/vaccinations/country_data/Vietnam.csv
@@ -55,7 +55,9 @@ Vietnam,2021-04-28,Oxford/AstraZeneca,https://vnexpress.net/hon-425-000-nguoi-da
 Vietnam,2021-04-29,Oxford/AstraZeneca,https://vnexpress.net/them-3-ca-lay-nhiem-tu-benh-nhan-covid-19-o-ha-nam-4270750.html,506435,506435,0
 Vietnam,2021-04-30,Oxford/AstraZeneca,https://tuoitre.vn/chieu-1-5-viet-nam-them-14-ca-covid-19-co-3-ca-cong-dong-o-ha-nam-20210501182737571.htm,509855,509855,0
 Vietnam,2021-05-01,Oxford/AstraZeneca,https://tuoitre.vn/sang-2-5-viet-nam-khong-them-ca-covid-19-moi-da-tiem-ngua-cho-hon-511-400-nguoi-20210502062146084.htm,511435,511435,0
-Vietnam,2021-05-02,Oxford/AstraZeneca,https://www.vietnamplus.vn/khong-ghi-nhan-ca-mac-moi-them-6143-nguoi-duoc-tiem-vaccine/710093.vnp,532247,532247,
-Vietnam,2021-05-03,Oxford/AstraZeneca,https://nhandan.com.vn/tin-tuc-y-te/sang-4-5-ghi-nhan-hai-ca-covid-19-nhap-canh-hai-ca-cong-dong-644477,539062,539062,
+Vietnam,2021-05-02,Oxford/AstraZeneca,https://www.vietnamplus.vn/khong-ghi-nhan-ca-mac-moi-them-6143-nguoi-duoc-tiem-vaccine/710093.vnp,532247,532247, 0
+Vietnam,2021-05-03,Oxford/AstraZeneca,https://nhandan.com.vn/tin-tuc-y-te/sang-4-5-ghi-nhan-hai-ca-covid-19-nhap-canh-hai-ca-cong-dong-644477,539062,539062, 0
 Vietnam,2021-05-04,Oxford/AstraZeneca,https://ncov.moh.gov.vn/vi/web/guest/-/6847426-2850,585539,585539,0
 Vietnam,2021-05-05,Oxford/AstraZeneca,https://ncov.moh.gov.vn/vi/web/guest/-/6847426-2919,675956,675956,0
+Vietnam,2021-05-06,Oxford/AstraZeneca,https://ncov.moh.gov.vn/web/guest/-/6847426-2998,747827,747827,0
+


### PR DESCRIPTION
> Về thông tin tiêm chủng, trong ngày hôm qua (6/5), trên cả nước có thêm 105.767 người được tiêm chủng vaccine phòng COVID-19, nâng tổng số người đã thực hiện tiêm vaccine phòng COVID-19 đợt 1 và 2 tại các tỉnh/TP lên 747.827 người. 

More than 105,000 people got vaccinated (I think this means receiving one dose of COVID-19 vaccine) yesterday. 747,827-105,767=642,060. The number of people vaccinated (received at least one dose of COVID-19 vaccine?) as of yesterday according to https://ncov.moh.gov.vn/vi/web/guest/-/6847426-2919 is 675,956. The difference is 30,000. Does that imply that the government may have started giving second doses?