### PR TITLE
Update Costa Rica.csv

### DIFF
--- a/public/data/vaccinations/country_data/Costa Rica.csv
+++ b/public/data/vaccinations/country_data/Costa Rica.csv
@@ -1,7 +1,7 @@
 location,date,vaccine,source_url,total_vaccinations,people_vaccinated,people_fully_vaccinated
-Costa Rica,2020-12-24,Pfizer/BioNTech,https://www.presidencia.go.cr/comunicados/2020/12/55-ticos-recibieron-la-primera-dosis-de-la-vacuna-contra-covid-19-este-24-de-diciembre/,55,,
-Costa Rica,2021-01-03,Pfizer/BioNTech,https://www.ccss.sa.cr/noticias/servicios_noticia?2-455-personas-iniciaron-nuevo-ano-con-la-primera-dosis-de-la-vacuna-contra-covid-19,2455,,
-Costa Rica,2021-01-08,Pfizer/BioNTech,https://www.ccss.sa.cr/noticias/servicios_noticia?9-751-personas-recibieron-primera-dosis-de-vacuna-para-evitar-la-covid19,9751,,
+Costa Rica,2020-12-24,Pfizer/BioNTech,https://www.presidencia.go.cr/comunicados/2020/12/55-ticos-recibieron-la-primera-dosis-de-la-vacuna-contra-covid-19-este-24-de-diciembre/,55,55,
+Costa Rica,2021-01-03,Pfizer/BioNTech,https://www.ccss.sa.cr/noticias/servicios_noticia?2-455-personas-iniciaron-nuevo-ano-con-la-primera-dosis-de-la-vacuna-contra-covid-19,2455,2455,
+Costa Rica,2021-01-08,Pfizer/BioNTech,https://www.ccss.sa.cr/noticias/servicios_noticia?9-751-personas-recibieron-primera-dosis-de-vacuna-para-evitar-la-covid19,9751,9751,
 Costa Rica,2021-01-15,Pfizer/BioNTech,https://www.ccss.sa.cr/noticias/servicios_noticia?ccss-registra-24-859-vacunas-contra-la-covid19-aplicadas,24859,24804,55
 Costa Rica,2021-01-18,Pfizer/BioNTech,https://www.larepublica.net/noticia/sube-a-29389-las-dosis-de-vacunas-covid-19-aplicadas-en-costa-rica/,29389,29257,132
 Costa Rica,2021-01-25,Pfizer/BioNTech,https://www.ccss.sa.cr/noticias/servicios_noticia?ccss-ha-colocado-48-128-vacunas-contra-la-covid-19,48128,45707,2421
@@ -14,11 +14,12 @@ Costa Rica,2021-03-05,Pfizer/BioNTech,https://www.ccss.sa.cr/web/coronavirus/vac
 Costa Rica,2021-03-08,Pfizer/BioNTech,https://www.ccss.sa.cr/web/coronavirus/vacunacion,204586,151841,52745
 Costa Rica,2021-03-12,Pfizer/BioNTech,https://www.ccss.sa.cr/web/coronavirus/vacunacion,241724,187826,53898
 Costa Rica,2021-03-15,Pfizer/BioNTech,https://www.ccss.sa.cr/web/coronavirus/vacunacion,248082,190088,57994
-Costa Rica,2021-03-22,"Oxford/AstraZeneca, Pfizer/BioNTech",https://www.ccss.sa.cr/web/coronavirus/vacunacion,312425,206198,106227
-Costa Rica,2021-03-24,"Oxford/AstraZeneca, Pfizer/BioNTech",https://www.ccss.sa.cr/web/coronavirus/vacunacion,348037,213404,134633
-Costa Rica,2021-03-29,"Oxford/AstraZeneca, Pfizer/BioNTech",https://www.ccss.sa.cr/web/coronavirus/vacunacion,384355,224092,160263
-Costa Rica,2021-04-06,"Oxford/AstraZeneca, Pfizer/BioNTech",https://www.ccss.sa.cr/web/coronavirus/vacunacion,504930,291368,213562
-Costa Rica,2021-04-12,"Oxford/AstraZeneca, Pfizer/BioNTech",https://www.ccss.sa.cr/web/coronavirus/vacunacion,586799,354291,232508
-Costa Rica,2021-04-19,"Oxford/AstraZeneca, Pfizer/BioNTech",https://www.ccss.sa.cr/web/coronavirus/vacunacion,698327,450593,247734
+Costa Rica,2021-03-22,Pfizer/BioNTech,https://www.ccss.sa.cr/web/coronavirus/vacunacion,312425,206198,106227
+Costa Rica,2021-03-24,Pfizer/BioNTech,https://www.ccss.sa.cr/web/coronavirus/vacunacion,348037,213404,134633
+Costa Rica,2021-03-29,Pfizer/BioNTech,https://www.ccss.sa.cr/web/coronavirus/vacunacion,384355,224092,160263
+Costa Rica,2021-04-06,Pfizer/BioNTech,https://www.ccss.sa.cr/web/coronavirus/vacunacion,504930,291368,213562
+Costa Rica,2021-04-12,Pfizer/BioNTech,https://www.ccss.sa.cr/web/coronavirus/vacunacion,586799,354291,232508
+Costa Rica,2021-04-19,Pfizer/BioNTech,https://www.ccss.sa.cr/web/coronavirus/vacunacion,698327,450593,247734
 Costa Rica,2021-04-26,"Oxford/AstraZeneca, Pfizer/BioNTech",https://www.ccss.sa.cr/web/coronavirus/vacunacion,818884,538682,280202
 Costa Rica,2021-05-03,"Oxford/AstraZeneca, Pfizer/BioNTech",https://www.ccss.sa.cr/web/coronavirus/vacunacion,950252,605099,345153
+Costa Rica,2021-05-06,"Oxford/AstraZeneca, Pfizer/BioNTech",https://www.larepublica.net/noticia/costa-rica-ya-supero-el-millon-de-vacunas-aplicadas,1000000,,


### PR DESCRIPTION
Morning! My first contribution here :)
Proposed changes:
1. Added new update
2. Added 1st doses from 12/24 to 01/08
3. Deleted "Oxford/AstraZeneca" in days it was not used (the first dose of this vaccine was applied on Monday 19th April around 12:44 p.m. local time on Press Conference [https://fb.watch/5kpgrJRMTI/], but the update from this day has data until 9:00 a.m. [https://www.ccss.sa.cr/noticias/servicios_noticia?cantidad-de-vacunas-aplicadas-contra-la-covid19-ronda-las-700-mil-dosis])