### PR TITLE
Update Panama.csv

### DIFF
--- a/public/data/vaccinations/country_data/Panama.csv
+++ b/public/data/vaccinations/country_data/Panama.csv
@@ -71,5 +71,6 @@ Panama,2021-04-29,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINS
 Panama,2021-04-30,"Pfizer/BioNTech, Oxford/AstraZeneca",http://minsa.gob.pa/noticia/comunicado-ndeg-430,672846,,190781
 Panama,2021-05-02,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1389025402946035712,687653,496449,191204
 Panama,2021-05-03,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1389360276970131456,692764,501055,191709
-Panama,2021-05-04,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1389744278679826434,695783,501055,192016
-Panama,2021-05-05,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1390085715032256518,706271,501055,213923
+Panama,2021-05-04,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1389744278679826434,695783,503767,192016
+Panama,2021-05-05,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1390085715032256518,706271,492348,213923
+Panama,2021-05-06,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1390441358050144263,731189,496123,235066


### PR DESCRIPTION
Vaccination update against COVID-19 in the Republic of Panama corresponding to May 4, 5 and 6 reported by the Ministry of Health.