### PR TITLE
Added Oxford/AstraZeneca for Malaysia

### DIFF
--- a/scripts/scripts/vaccinations/src/vax/incremental/malaysia.py
+++ b/scripts/scripts/vaccinations/src/vax/incremental/malaysia.py
@@ -29,7 +29,7 @@ def enrich_location(ds: pd.Series) -> pd.Series:
 
 
 def enrich_vaccine(ds: pd.Series) -> pd.Series:
-    return enrich_data(ds, "vaccine", "Pfizer/BioNTech, Sinovac")
+    return enrich_data(ds, "vaccine", "Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac")
 
 
 def enrich_source(ds: pd.Series) -> pd.Series:


### PR DESCRIPTION
Malaysia begins using Oxford/AstraZeneca vaccine on May 5.
Source: https://twitter.com/JKJAVMY/status/1389825004578250753