### PR TITLE
Update Panama.csv

### DIFF
--- a/public/data/vaccinations/country_data/Panama.csv
+++ b/public/data/vaccinations/country_data/Panama.csv
@@ -68,9 +68,11 @@ Panama,2021-04-26,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINS
 Panama,2021-04-27,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1387216977845002243,640507,452242,188265
 Panama,2021-04-28,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1387585701131264000,643939,453873,190066
 Panama,2021-04-29,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1387935992707964931,672159,482089,190070
-Panama,2021-04-30,"Pfizer/BioNTech, Oxford/AstraZeneca",http://minsa.gob.pa/noticia/comunicado-ndeg-430,672846,,190781
-Panama,2021-05-02,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1389025402946035712,687653,,191204
-Panama,2021-05-03,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1389360276970131456,692764,,191709
-Panama,2021-05-04,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1389744278679826434,695783,,192016
-Panama,2021-05-05,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1390085715032256518,706271,492348,213923
-Panama,2021-05-06,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1390441358050144263/,731189,496131,235058
+Panama,2021-04-30,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1388268461294563338,672846,,190781
+Panama,2021-05-02,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1389025402946035712,687653,496449,191204
+Panama,2021-05-03,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1389360276970131456,692764,501055,191709
+Panama,2021-05-04,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1389744278679826434,695783,503767,192016
+Panama,2021-05-05,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1390085715032256518,706271,,213873
+Panama,2021-05-06,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1390441358050144263,731189,,235066
+Panama,2021-05-07,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1390810993421398026,758563,507759,250804
+


### PR DESCRIPTION
Vaccination update against COVID-19 in the Republic of Panama corresponding to April 30, and from May 2 to 7 with the correction of the first dose so that its increase is the the right one. I appreciate the correction. 😎🇵🇦