### PR TITLE
Fix swapped values for Malta's vaccination data

### DIFF
--- a/public/data/vaccinations/country_data/Malta.csv
+++ b/public/data/vaccinations/country_data/Malta.csv
@@ -107,4 +107,4 @@ Malta,2021-05-02,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://github.c
 Malta,2021-05-03,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://github.com/COVID19-Malta/COVID19-Cases,346951,237018,109933
 Malta,2021-05-04,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://github.com/COVID19-Malta/COVID19-Cases,352421,241103,111318
 Malta,2021-05-05,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://github.com/COVID19-Malta/COVID19-Cases,359429,246698,112731
-Malta,2021-05-06,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://github.com/COVID19-Malta/COVID19-Cases,365902,114115,251787
+Malta,2021-05-06,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://github.com/COVID19-Malta/COVID19-Cases,365902,251787,114115


### PR DESCRIPTION
Malta's values for people_vaccinated and people_fully_vaccinated were swapped for 2021-05-06