### PR TITLE
Update Panama.csv

### DIFF
--- a/public/data/vaccinations/country_data/Panama.csv
+++ b/public/data/vaccinations/country_data/Panama.csv
@@ -75,3 +75,4 @@ Panama,2021-05-04,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINS
 Panama,2021-05-05,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1390085715032256518,706271,492348,213923
 Panama,2021-05-06,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1390441358050144263/,731189,496131,235058
 Panama,2021-05-07,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1390810993421398026,758563,507759,250804
+Panama,2021-05-08,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1391200262400974854,769842,514300,255542


### PR DESCRIPTION
Vaccination update against COVID-19 in the Republic of Panama corresponding to May 8 reported by the Ministry of Health. It tells me if the correction of the first dose is correct.