### PR TITLE
Update North Macedonia.csv

### DIFF
--- a/public/data/vaccinations/country_data/North Macedonia.csv
+++ b/public/data/vaccinations/country_data/North Macedonia.csv
@@ -24,4 +24,5 @@ North Macedonia,2021-04-27,"Oxford/AstraZeneca, Pfizer/BioNTech, Sputnik V",http
 North Macedonia,2021-04-30,"Oxford/AstraZeneca, Pfizer/BioNTech, Sputnik V",https://kovid19vakcinacija.mk/,61603,61603,
 North Macedonia,2021-05-04,"Oxford/AstraZeneca, Pfizer/BioNTech, Sputnik V",https://kovid19vakcinacija.mk/,66086,66086,
 North Macedonia,2021-05-05,"Oxford/AstraZeneca, Pfizer/BioNTech, Sputnik V",https://kovid19vakcinacija.mk/,74076,74076,
-North Macedonia,2021-05-08,"Oxford/AstraZeneca, Pfizer/BioNTech, Sputnik V",https://kovid19vakcinacija.mk/,97004,97004,
+
+North Macedonia,2021-05-08,"Oxford/AstraZeneca, Pfizer/BioNTech, Sputnik V, Sinopharm/Beijing",https://www.facebook.com/filipce.venko/photos/a.1819648248342200/2682804082026608/,130878,130878,22900


### PR DESCRIPTION
Information about North Macedonia's vaccination progress can be found on this link: https://www.facebook.com/filipce.venko. From May 8 2021 onwards, there will be a daily progress graph on the Minister of Health's Facebook page. What I have updated are numbers about the previous day, May 8 (since today is May 9) - which can be found here: https://www.facebook.com/filipce.venko/photos/a.1819648248342200/2682804082026608/. The information on the graph written in Macedonian is as following: first square - "Number of people vaccinated in the previous day", second square - "Number of total vaccinations", third square - "Number of fully vaccinated people", fourth square - "Number of people interested in getting a vaccine." North Macedonia has started administering the Sinopharm/Beijing vaccine along with the other three.