### PR TITLE
Update Panama.csv

### DIFF
--- a/public/data/vaccinations/country_data/Panama.csv
+++ b/public/data/vaccinations/country_data/Panama.csv
@@ -45,7 +45,7 @@ Panama,2021-03-28,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1376326017
 Panama,2021-03-29,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1376662708737675300,358277,256704,101577
 Panama,2021-04-01,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1377778846490054656,373491,269072,101722
 Panama,2021-04-05,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1379229927845810177,387580,269747,117833
-Panama,2021-04-06,Pfizer/BioNTech,https://www.facebook.com/minsapma/videos/814215869178702,408618,276374,132244
+Panama,2021-04-06,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1379615388573519874,408618,276374,132244
 Panama,2021-04-07,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1379973785332244486,440787,300804,139983
 Panama,2021-04-08,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1380301588263268352,456929,311480,145449
 Panama,2021-04-09,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1380688588652826625,478146,332630,145516
@@ -68,7 +68,7 @@ Panama,2021-04-26,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINS
 Panama,2021-04-27,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1387216977845002243,640507,452242,188265
 Panama,2021-04-28,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1387585701131264000,643939,453873,190066
 Panama,2021-04-29,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1387935992707964931,672159,482089,190070
-Panama,2021-04-30,"Pfizer/BioNTech, Oxford/AstraZeneca",http://minsa.gob.pa/noticia/comunicado-ndeg-430,672846,,190781
+Panama,2021-04-30,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1388268461294563338,672846,,190781
 Panama,2021-05-02,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1389025402946035712,687653,,191204
 Panama,2021-05-03,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1389360276970131456,692764,,191709
 Panama,2021-05-04,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1389744278679826434,695783,,192016
@@ -76,4 +76,6 @@ Panama,2021-05-05,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINS
 Panama,2021-05-06,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1390441358050144263,731189,496131,235058
 Panama,2021-05-07,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1390810993421398026,758563,507759,250804
 Panama,2021-05-08,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1391200262400974854,769842,514300,255542
-Panama,2021-05-09,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1391548126616592387,780569,524958,255610
+Panama,2021-05-09,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1391548126616592387,770569,514959,255610
+Panama,2021-05-10,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1391900694798651392,775995,518957,256998
+Panama,2021-05-11,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1392296148459741187,778174,519371,258803


### PR DESCRIPTION
Update and Correction of Vaccination against COVID-19 in the Republic of Panama corresponding to days 9, 10 and 11 reported by the Ministry of Health.