### PR TITLE
Update Panama.csv

### DIFF
--- a/public/data/vaccinations/country_data/Panama.csv
+++ b/public/data/vaccinations/country_data/Panama.csv
@@ -37,12 +37,25 @@ Panama,2021-03-08,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1369072778
 Panama,2021-03-09,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1369457216869306371,214492,208590,5902
 Panama,2021-03-10,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1369826724284923914,224765,218861,5904
 Panama,2021-03-11,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1370185311289016326,233365,227461,5904
+Panama,2021-03-12,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1370521869917560832,245177,239273,5904
+Panama,2021-03-13,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1370898588067315715,252313,246409,5904
+Panama,2021-03-14,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1371267700576677892,253800,247896,5904
+Panama,2021-03-15,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1371632651845664769,259843,245915,13928
+Panama,2021-03-16,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1371991871925460992,266298,243243,23056
 Panama,2021-03-18,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1372715275716558855,287086,235570,51516
+Panama,2021-03-19,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1373089053965488130,297165,238485,58680
+Panama,2021-03-20,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1373457164694654977,309324,248644,60680
+Panama,2021-03-21,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1373802119959023621,309660,248698,60962
+Panama,2021-03-22,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1374158652534362116,310108,247188,62920
+Panama,2021-03-23,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1374546941422501890,312761,246718,66043
+Panama,2021-03-24,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1374858925162520577,320079,240361,79718
 Panama,2021-03-25,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1375225055714623488,329822,238228,91594
 Panama,2021-03-26,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1375583976727977985,342716,243926,98790
 Panama,2021-03-27,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1375970370679930880,352876,251650,101226
 Panama,2021-03-28,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1376326017917333507,357431,255881,101550
 Panama,2021-03-29,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1376662708737675300,358277,256704,101577
+Panama,2021-03-30,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1377060139803545601,364079,262396,101683
+Panama,2021-03-31,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1377402299572613121,370793,262090,101703
 Panama,2021-04-01,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1377778846490054656,373491,269072,101722
 Panama,2021-04-05,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1379229927845810177,387580,269747,117833
 Panama,2021-04-06,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1379615388573519874,408618,276374,132244
@@ -50,6 +63,7 @@ Panama,2021-04-07,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1379973785
 Panama,2021-04-08,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1380301588263268352,456929,311480,145449
 Panama,2021-04-09,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1380688588652826625,478146,332630,145516
 Panama,2021-04-10,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1381036525102710785,490911,345248,145663
+Panama,2021-04-11,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1381399460203397121,498584,352903,145691
 Panama,2021-04-12,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1381779875862880259,505005,345894,159111
 Panama,2021-04-13,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1382141574864379905,518629,349033,169596
 Panama,2021-04-14,Pfizer/BioNTech,https://twitter.com/MINSAPma/status/1382468563919900672,529017,352276,176741
@@ -79,3 +93,4 @@ Panama,2021-05-08,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINS
 Panama,2021-05-09,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1391548126616592387,770569,514959,255610
 Panama,2021-05-10,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1391900694798651392,775995,518957,256998
 Panama,2021-05-11,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1392296148459741187,778174,519371,258803
+Panama,2021-05-12,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1392621192981397513,779163,520260,258903


### PR DESCRIPTION
Vaccination update against COVID-19 in the Republic of Panama corresponding to the days 12, 13, 14, 15, 16, 19, 20, 21, 22, 23, 30 and 31 March, April 11 and May 12 reported by the Ministry of Health