### PR TITLE
Update Vietnam.csv

### DIFF
--- a/public/data/vaccinations/country_data/Vietnam.csv
+++ b/public/data/vaccinations/country_data/Vietnam.csv
@@ -62,6 +62,10 @@ Vietnam,2021-05-05,Oxford/AstraZeneca,https://ncov.moh.gov.vn/vi/web/guest/-/684
 Vietnam,2021-05-06,Oxford/AstraZeneca,https://ncov.moh.gov.vn/web/guest/-/6847426-2998,,747827,
 Vietnam,2021-05-07,Oxford/AstraZeneca,https://ncov.moh.gov.vn/web/guest/-/6847426-3088,,801957,
 Vietnam,2021-05-08,Oxford/AstraZeneca,https://ncov.moh.gov.vn/web/guest/-/6847426-3162,,832635,
-Vietnam,2021-05-09,Oxford/AstraZeneca,https://ncov.moh.gov.vn/web/guest/-/6847426-3244,888658,851513,37145
+Vietnam,2021-05-09,Oxford/AstraZeneca,https://ncov.moh.gov.vn/web/guest/-/6847426-3244,,851513,
 Vietnam,2021-05-10,Oxford/AstraZeneca,https://ncov.moh.gov.vn/web/guest/-/6847426-3310,892454,,
 Vietnam,2021-05-11,Oxford/AstraZeneca,https://ncov.moh.gov.vn/vi/web/guest/-/6847426-3370,,887705,
+Vietnam,2021-05-12,Oxford/AstraZeneca,https://moh.gov.vn/tin-lien-quan/-/asset_publisher/vjYyM7O9aWnX/content/bo-y-te-ca-nuoc-co-942-030-nguoi-a-tiem-chung-vac-xin-phong-covid-19,942030,,
+Vietnam,2021-05-13,Oxford/AstraZeneca,https://ncov.moh.gov.vn/web/guest/-/6847426-3474,959182,,
+Vietnam,2021-05-14,Oxford/AstraZeneca,https://ncov.moh.gov.vn/web/guest/-/6847426-3506,969697,,21042
+Vietnam,2021-05-15,Oxford/AstraZeneca,https://ncov.moh.gov.vn/web/guest/-/6847426-3537,977032,,22512 


### PR DESCRIPTION
Update for 15/05. I also think that we should not use the data about 9/5 total vaccinations from WHO for consistency. So far, we have only used data from MoH. There is only a 4k difference between 888658 ( 9 May from WHO) and 892454 (10 May from MoH), (about 4,000 people vaccinated a day?) Furthermore, the number of those fully vaccinated (37k) is higher than that reported by MoH on 16/05 (https://ncov.moh.gov.vn/web/guest/-/6847426-3537). Both figures (total vaccinations from WHO and people vaccinated from MoH) referred to 9 May but I think the number from WHO was referencing a later data report (or different timezone?). MoH numbers are usually updated daily at 5-7 a.m,(UTC +7), with data current as of 4 p.m.(UTC +7) the previous day, while the other does not have any further information.