### PR TITLE
VAX: J&J support Greece

### DIFF
--- a/scripts/scripts/vaccinations/output/Greece.csv
+++ b/scripts/scripts/vaccinations/output/Greece.csv
@@ -1,124 +1,125 @@
-date,total_vaccinations,people_vaccinated,people_fully_vaccinated,location,vaccine,source_url
-2020-12-28,447,447,,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2020-12-29,1077,1077,,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2020-12-30,1722,1722,,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2020-12-31,2339,2339,,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-01-01,2603,2603,,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-01-02,3149,3149,,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-01-03,3869,3869,,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-01-04,10327,10327,,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-01-05,16631,16631,,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-01-06,20616,20616,,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-01-07,26445,26445,,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-01-08,35272,35272,,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-01-09,40427,40427,,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-01-10,44645,44645,,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-01-11,50045,50045,,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-01-12,56475,56475,,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-01-13,64932,64932,,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-01-14,70960,70960,,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-01-15,75412,75412,,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-01-16,80391,80389,2,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-01-18,85898,85475,423,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-01-19,94454,93382,1072,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-01-20,109831,108167,1664,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-01-21,125928,123667,2261,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-01-22,143877,141298,2579,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-01-23,160101,156966,3135,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-01-25,179951,171890,8061,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-01-26,197755,184610,13145,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-01-27,216040,198161,17879,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-01-28,234285,210488,23797,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-01-29,253363,220621,32742,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-01-30,271287,232399,38888,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-02-01,293817,247251,46566,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-02-02,315628,261543,54085,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-02-03,338122,276103,62019,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-02-04,359723,291259,68464,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-02-05,380136,306441,73695,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-02-06,397857,318097,79760,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-02-08,417565,332812,84753,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-02-09,437872,345290,92582,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-02-10,459535,353412,106123,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-02-11,482416,360800,121616,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-02-12,506038,366749,139289,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-02-13,526369,371462,154907,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-02-15,554745,386049,168696,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-02-16,575766,397840,177926,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-02-17,603667,412970,190697,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-02-18,634037,430124,203913,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-02-19,664347,449073,215274,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-02-20,693436,465842,227594,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-02-21,697245,467656,229589,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-02-22,730410,486820,243590,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-02-23,762624,505148,257476,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-02-24,794347,522510,271837,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-02-25,826370,540039,286331,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-02-26,857306,556380,300926,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-02-27,885821,572174,313647,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-03-01,921189,594053,327136,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-03-02,957139,617737,339402,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-03-03,991409,643218,348191,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-03-04,1024711,669152,355559,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-03-05,1059304,697876,361428,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-03-06,1091749,725388,366361,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-03-08,1126060,753636,372424,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-03-09,1158386,780536,377850,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-03-10,1190723,807280,383443,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-03-11,1222393,831761,390632,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-03-12,1254087,855151,398936,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-03-13,1283472,877402,406070,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-03-15,1285437,877644,407793,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-03-16,1316554,895920,420634,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-03-17,1345735,915641,430094,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-03-18,1375828,935269,440559,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-03-19,1407064,956745,450319,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-03-20,1436491,977045,459446,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-03-22,1469020,997959,471061,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-03-23,1503487,1018670,484817,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-03-24,1536957,1035543,501414,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-03-25,1537104,1035659,501445,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-03-26,1572726,1046291,526435,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-03-27,1604238,1055744,548494,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-03-29,1635676,1066873,568803,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-03-30,1668956,1080658,588298,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-03-31,1699807,1092633,607174,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-04-01,1739051,1114363,624688,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-04-02,1777502,1135585,641917,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-04-03,1830362,1171420,658942,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-04-05,1886370,1222682,663688,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-04-06,1946339,1269938,676401,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-04-07,2003644,1312896,690748,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-04-08,2058750,1353956,704794,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-04-09,2114222,1394013,720209,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-04-10,2169353,1435503,733850,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-04-12,2225878,1480479,745399,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-04-13,2280934,1524902,756032,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-04-14,2334557,1569559,764998,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-04-15,2387148,1620067,767081,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-04-16,2440210,1671324,768886,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-04-17,2491857,1721650,770207,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-04-19,2546154,1774120,772034,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-04-20,2600998,1826618,774380,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-04-21,2652448,1876009,776439,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-04-22,2708780,1924630,784150,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-04-23,2765367,1971361,794006,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-04-24,2821625,2004512,817113,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-04-26,2883199,2032090,851109,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-04-27,2945058,2063824,881234,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-04-28,3009488,2099343,910145,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-04-29,3075698,2131890,943808,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-04-30,3097693,2153560,944133,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-05-01,3115339,2170847,944492,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-05-03,3136791,2191449,945342,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-05-04,3201212,2214648,986564,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-05-05,3309765,2272642,1037123,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-05-06,3424441,2333913,1090528,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-05-07,3535148,2391470,1143678,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-05-08,3647616,2450303,1197313,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-05-10,3760640,2507229,1253411,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-05-11,3868356,2561858,1306498,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-05-12,3973336,2615123,1358213,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-05-13,4079168,2666895,1412273,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-05-14,4185347,2718390,1466957,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
-2021-05-15,4292541,2772414,1520127,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/
+date,location,vaccine,source_url,total_vaccinations,people_vaccinated,people_fully_vaccinated
+2020-12-28,Greece,Pfizer/BioNTech,https://www.data.gov.gr/datasets/mdg_emvolio/,447,447,
+2020-12-29,Greece,Pfizer/BioNTech,https://www.data.gov.gr/datasets/mdg_emvolio/,1077,1077,
+2020-12-30,Greece,Pfizer/BioNTech,https://www.data.gov.gr/datasets/mdg_emvolio/,1722,1722,
+2020-12-31,Greece,Pfizer/BioNTech,https://www.data.gov.gr/datasets/mdg_emvolio/,2339,2339,
+2021-01-01,Greece,Pfizer/BioNTech,https://www.data.gov.gr/datasets/mdg_emvolio/,2603,2603,
+2021-01-02,Greece,Pfizer/BioNTech,https://www.data.gov.gr/datasets/mdg_emvolio/,3149,3149,
+2021-01-03,Greece,Pfizer/BioNTech,https://www.data.gov.gr/datasets/mdg_emvolio/,3869,3869,
+2021-01-04,Greece,Pfizer/BioNTech,https://www.data.gov.gr/datasets/mdg_emvolio/,10327,10327,
+2021-01-05,Greece,Pfizer/BioNTech,https://www.data.gov.gr/datasets/mdg_emvolio/,16631,16631,
+2021-01-06,Greece,Pfizer/BioNTech,https://www.data.gov.gr/datasets/mdg_emvolio/,20616,20616,
+2021-01-07,Greece,Pfizer/BioNTech,https://www.data.gov.gr/datasets/mdg_emvolio/,26445,26445,
+2021-01-08,Greece,Pfizer/BioNTech,https://www.data.gov.gr/datasets/mdg_emvolio/,35272,35272,
+2021-01-09,Greece,Pfizer/BioNTech,https://www.data.gov.gr/datasets/mdg_emvolio/,40427,40427,
+2021-01-10,Greece,Pfizer/BioNTech,https://www.data.gov.gr/datasets/mdg_emvolio/,44645,44645,
+2021-01-11,Greece,Pfizer/BioNTech,https://www.data.gov.gr/datasets/mdg_emvolio/,50045,50045,
+2021-01-12,Greece,Pfizer/BioNTech,https://www.data.gov.gr/datasets/mdg_emvolio/,56475,56475,
+2021-01-13,Greece,"Moderna, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,64932,64932,
+2021-01-14,Greece,"Moderna, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,70960,70960,
+2021-01-15,Greece,"Moderna, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,75412,75412,
+2021-01-16,Greece,"Moderna, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,80391,80389,2
+2021-01-18,Greece,"Moderna, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,85898,85475,423
+2021-01-19,Greece,"Moderna, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,94454,93382,1072
+2021-01-20,Greece,"Moderna, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,109831,108167,1664
+2021-01-21,Greece,"Moderna, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,125928,123667,2261
+2021-01-22,Greece,"Moderna, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,143877,141298,2579
+2021-01-23,Greece,"Moderna, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,160101,156966,3135
+2021-01-25,Greece,"Moderna, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,179951,171890,8061
+2021-01-26,Greece,"Moderna, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,197755,184610,13145
+2021-01-27,Greece,"Moderna, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,216040,198161,17879
+2021-01-28,Greece,"Moderna, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,234285,210488,23797
+2021-01-29,Greece,"Moderna, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,253363,220621,32742
+2021-01-30,Greece,"Moderna, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,271287,232399,38888
+2021-02-01,Greece,"Moderna, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,293817,247251,46566
+2021-02-02,Greece,"Moderna, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,315628,261543,54085
+2021-02-03,Greece,"Moderna, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,338122,276103,62019
+2021-02-04,Greece,"Moderna, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,359723,291259,68464
+2021-02-05,Greece,"Moderna, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,380136,306441,73695
+2021-02-06,Greece,"Moderna, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,397857,318097,79760
+2021-02-08,Greece,"Moderna, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,417565,332812,84753
+2021-02-09,Greece,"Moderna, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,437872,345290,92582
+2021-02-10,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,459535,353412,106123
+2021-02-11,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,482416,360800,121616
+2021-02-12,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,506038,366749,139289
+2021-02-13,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,526369,371462,154907
+2021-02-15,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,554745,386049,168696
+2021-02-16,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,575766,397840,177926
+2021-02-17,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,603667,412970,190697
+2021-02-18,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,634037,430124,203913
+2021-02-19,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,664347,449073,215274
+2021-02-20,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,693436,465842,227594
+2021-02-21,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,697245,467656,229589
+2021-02-22,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,730410,486820,243590
+2021-02-23,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,762624,505148,257476
+2021-02-24,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,794347,522510,271837
+2021-02-25,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,826370,540039,286331
+2021-02-26,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,857306,556380,300926
+2021-02-27,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,885821,572174,313647
+2021-03-01,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,921189,594053,327136
+2021-03-02,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,957139,617737,339402
+2021-03-03,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,991409,643218,348191
+2021-03-04,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,1024711,669152,355559
+2021-03-05,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,1059304,697876,361427
+2021-03-06,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,1091749,725388,366360
+2021-03-08,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,1126060,753636,372423
+2021-03-09,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,1158386,780536,377848
+2021-03-10,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,1190723,807280,383441
+2021-03-11,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,1222393,831761,390629
+2021-03-12,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,1254087,855151,398933
+2021-03-13,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,1283472,877402,406067
+2021-03-15,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,1285437,877644,407790
+2021-03-16,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,1316554,895920,420630
+2021-03-17,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,1345735,915641,430089
+2021-03-18,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,1375828,935269,440554
+2021-03-19,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,1407064,956745,450314
+2021-03-20,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,1436491,977045,459441
+2021-03-22,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,1469020,997959,471056
+2021-03-23,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,1503487,1018670,484812
+2021-03-24,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,1536957,1035543,501409
+2021-03-25,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,1537104,1035659,501440
+2021-03-26,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,1572726,1046291,526429
+2021-03-27,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,1604238,1055744,548488
+2021-03-29,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,1635676,1066873,568796
+2021-03-30,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,1668956,1080658,588291
+2021-03-31,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,1699807,1092633,607167
+2021-04-01,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,1739051,1114363,624681
+2021-04-02,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,1777502,1135585,641909
+2021-04-03,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,1830362,1171420,658934
+2021-04-05,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,1886370,1222682,663680
+2021-04-06,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,1946339,1269938,676393
+2021-04-07,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,2003644,1312896,690740
+2021-04-08,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,2058750,1353956,704785
+2021-04-09,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,2114222,1394013,720200
+2021-04-10,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,2169353,1435503,733840
+2021-04-12,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,2225878,1480479,745389
+2021-04-13,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,2280934,1524902,756022
+2021-04-14,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,2334557,1569559,764988
+2021-04-15,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,2387148,1620067,767071
+2021-04-16,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,2440210,1671324,768876
+2021-04-17,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,2491857,1721650,770197
+2021-04-19,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,2546154,1774120,772024
+2021-04-20,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,2600998,1826618,774370
+2021-04-21,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,2652448,1876009,776429
+2021-04-22,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,2708780,1924630,784140
+2021-04-23,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,2765367,1971361,793996
+2021-04-24,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,2821625,2004512,817103
+2021-04-26,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,2883199,2032090,851099
+2021-04-27,Greece,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,2945058,2063824,881224
+2021-04-28,Greece,"Johnson&Johnson, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,3009488,2099343,910135
+2021-04-29,Greece,"Johnson&Johnson, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,3075698,2131890,943798
+2021-04-30,Greece,"Johnson&Johnson, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,3097693,2153560,944123
+2021-05-01,Greece,"Johnson&Johnson, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,3115339,2170847,944481
+2021-05-03,Greece,"Johnson&Johnson, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,3136791,2191449,945331
+2021-05-04,Greece,"Johnson&Johnson, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,3201212,2214648,986552
+2021-05-05,Greece,"Johnson&Johnson, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,3309765,2272642,1041838
+2021-05-06,Greece,"Johnson&Johnson, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,3424441,2333913,1100081
+2021-05-07,Greece,"Johnson&Johnson, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,3535148,2391470,1158110
+2021-05-08,Greece,"Johnson&Johnson, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,3647616,2450303,1216683
+2021-05-10,Greece,"Johnson&Johnson, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,3760640,2507229,1277825
+2021-05-11,Greece,"Johnson&Johnson, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,3868356,2561858,1335798
+2021-05-12,Greece,"Johnson&Johnson, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,3973336,2615123,1392281
+2021-05-13,Greece,"Johnson&Johnson, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,4079168,2666895,1450838
+2021-05-14,Greece,"Johnson&Johnson, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,4185347,2718390,1510095
+2021-05-15,Greece,"Johnson&Johnson, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,4292541,2772414,1568229
+2021-05-17,Greece,"Johnson&Johnson, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.data.gov.gr/datasets/mdg_emvolio/,4405618,2836972,1624604

--- a/scripts/scripts/vaccinations/src/vax/batch/greece.py
+++ b/scripts/scripts/vaccinations/src/vax/batch/greece.py
@@ -1,69 +1,104 @@
-import os
-import json
-
+from datetime import date
 import requests
+from functools import reduce
 import pandas as pd
 
-
-def read(source: str, access_token: str) -> pd.DataFrame:
-    response = requests.get(source, headers={"Authorization": f"Token {access_token}"})
-    return pd.DataFrame.from_records(response.json())
+from vax.utils.utils import date_formatter
 
 
-def format_columns(df: pd.DataFrame) -> pd.DataFrame:
-    return df.rename(
-        columns={
-            "referencedate": "date",
-            "totalvaccinations": "total_vaccinations",
-            "totaldistinctpersons": "people_vaccinated",
+class Greece:
+
+    def __init__(self, source_url: str, source_url_ref: str, location: str):
+        """Constructor.
+
+        Args:
+            source_url (str): Source data url
+            source_url_ref (str): Source data reference url
+            location (str): Location name
+        """
+        self.source_url = source_url
+        self.source_url_ref = source_url_ref
+        self.location = location
+
+    def read(self) -> pd.DataFrame:
+        data = requests.get(self.source_url).json()
+        return self.parse_data(data)
+
+    def parse_data(self, data: dict):
+        metrics_mapping = {
+            "Συνολικοί εμβολιασμοί με τουλάχιστον 1 δόση": "people_partly_vaccinated",
+            "Συνολικοί ολοκληρωμένοι εμβολιασμοί": "people_fully_vaccinated",
+            "Συνολικοί εμβολιασμοί": "total_vacinations",
+            "Σύνολο ατόμων που έχουν εμβολιαστεί ": "people_vaccinated",
         }
-    )
+        dfs = [
+            pd.DataFrame.from_records(d["data"]).rename(columns={
+                "x": "date",
+                "y": metrics_mapping[d["label"]],
+            })
+        for d in data]
+        return reduce(lambda left, right: pd.merge(left, right, on=['date'], how='inner'), dfs)
+
+    def pipe_replace_nulls_with_nans(self, df: pd.DataFrame) -> pd.DataFrame:
+        return df.assign(people_fully_vaccinated=df.people_fully_vaccinated.replace(0, pd.NA))
+
+    def pipe_date(self, df: pd.DataFrame) -> pd.DataFrame:
+        return df.assign(date=df.date.apply(lambda x: date_formatter(x, "%Y-%m-%dT%H:%M:%S", "%Y-%m-%d")))
+
+    def pipe_metadata(self, df: pd.DataFrame) -> pd.DataFrame:
+        return df.assign(
+            location=self.location,
+            source_url=self.source_url_ref,
+        )
+
+    def pipe_vaccine(self, df: pd.DataFrame) -> pd.DataFrame:
+        def _enrich_vaccine_name(date: str) -> str:
+            if date < "2021-01-13":
+                return "Pfizer/BioNTech"
+            elif "2021-01-13" <= date < "2021-02-10":
+                return "Moderna, Pfizer/BioNTech"
+            elif "2021-02-10" <= date < "2021-04-28": 
+                return "Moderna, Oxford/AstraZeneca, Pfizer/BioNTech"
+            elif "2021-04-28" <= date:
+                return "Johnson&Johnson, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech"
+        return df.assign(vaccine=df.date.apply(_enrich_vaccine_name))
+
+    def pipe_select_output_columns(df: pd.DataFrame) -> pd.DataFrame:
+        return df[[
+            "date",
+            "location",
+            "vaccine",
+            "source_url",
+            "total_vaccinations",
+            "people_vaccinated",
+            "people_fully_vaccinated",
+        ]]
+
+    def pipeline(self, df: pd.DataFrame) -> pd.DataFrame:
+        return (
+            df
+            .pipe(self.pipe_replace_nulls_with_nans)
+            .pipe(self.pipe_date)
+            .pipe(self.pipe_metadata)
+            .pipe(self.pipe_vaccine)
+            .pipe(self.pipe_select_output_columns)
+        )
+
+    def to_csv(self, paths):
+        """Generalized."""
+        df = self.read().pipe(self.pipeline)
+        df.to_csv(
+            paths.tmp_vax_out(self.location),
+            index=False
+        )
 
 
-def aggregate(df: pd.DataFrame) -> pd.DataFrame:
-    return df.groupby(by="date", as_index=False)[
-        ["total_vaccinations", "people_vaccinated"]
-    ].sum()
-
-
-def enrich_people_fully_vaccinated(df: pd.DataFrame) -> pd.DataFrame:
-    return df.assign(
-        people_fully_vaccinated=df.total_vaccinations - df.people_vaccinated
-    )
-
-
-def replace_nulls_with_nans(df: pd.DataFrame) -> pd.DataFrame:
-    return df.assign(people_fully_vaccinated=df.people_fully_vaccinated.replace(0, pd.NA))
-
-
-def format_date(df: pd.DataFrame) -> pd.DataFrame:
-    return df.assign(date=df.date.str.slice(0, 10))
-
-
-def enrich_metadata(df: pd.DataFrame) -> pd.DataFrame:
-    return df.assign(
+def main(paths, greece_api_token):
+    Greece(
+        source_url="https://www.data.gov.gr/api/v1/summary/mdg_emvolio?date_from=2020-12-28",
+        source_url_ref="https://www.data.gov.gr/datasets/mdg_emvolio/",
         location="Greece",
-        vaccine="Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",
-        source_url="https://www.data.gov.gr/datasets/mdg_emvolio/",
-    )
-
-
-def pipeline(df: pd.DataFrame) -> pd.DataFrame:
-    return (
-        df
-        .pipe(format_columns)
-        .pipe(aggregate)
-        .pipe(enrich_people_fully_vaccinated)
-        .pipe(replace_nulls_with_nans)
-        .pipe(format_date)
-        .pipe(enrich_metadata)
-    )
-
-
-def main(paths, access_token: str):
-    source = "https://data.gov.gr/api/v1/query/mdg_emvolio"
-    destination = paths.tmp_vax_out("Greece")
-    read(source, access_token).pipe(pipeline).to_csv(destination, index=False)
+    ).to_csv(paths)
 
 
 if __name__ == "__main__":

--- a/scripts/scripts/vaccinations/src/vax/batch/greece.py
+++ b/scripts/scripts/vaccinations/src/vax/batch/greece.py
@@ -28,7 +28,7 @@ class Greece:
         metrics_mapping = {
             "Συνολικοί εμβολιασμοί με τουλάχιστον 1 δόση": "people_partly_vaccinated",
             "Συνολικοί ολοκληρωμένοι εμβολιασμοί": "people_fully_vaccinated",
-            "Συνολικοί εμβολιασμοί": "total_vacinations",
+            "Συνολικοί εμβολιασμοί": "total_vaccinations",
             "Σύνολο ατόμων που έχουν εμβολιαστεί ": "people_vaccinated",
         }
         dfs = [
@@ -43,7 +43,7 @@ class Greece:
         return df.assign(people_fully_vaccinated=df.people_fully_vaccinated.replace(0, pd.NA))
 
     def pipe_date(self, df: pd.DataFrame) -> pd.DataFrame:
-        return df.assign(date=df.date.apply(lambda x: date_formatter(x, "%Y-%m-%dT%H:%M:%S", "%Y-%m-%d")))
+        return df.assign(date=date_formatter(df.date, "%Y-%m-%dT%H:%M:%S", "%Y-%m-%d"))
 
     def pipe_metadata(self, df: pd.DataFrame) -> pd.DataFrame:
         return df.assign(
@@ -63,7 +63,7 @@ class Greece:
                 return "Johnson&Johnson, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech"
         return df.assign(vaccine=df.date.apply(_enrich_vaccine_name))
 
-    def pipe_select_output_columns(df: pd.DataFrame) -> pd.DataFrame:
+    def pipe_select_output_columns(self, df: pd.DataFrame) -> pd.DataFrame:
         return df[[
             "date",
             "location",


### PR DESCRIPTION
- Using public API: https://www.data.gov.gr/api/v1/summary/mdg_emvolio?date_from=2020-12-28.
- Correctly accounting for single-shot vaccine doses J&J