### PR TITLE
ENH: Automate URL cleaning

### DIFF
--- a/scripts/scripts/vaccinations/src/vax/process/process.py
+++ b/scripts/scripts/vaccinations/src/vax/process/process.py
@@ -2,6 +2,7 @@ from datetime import datetime
 import pandas as pd
 
 from vax.utils.checks import country_df_sanity_checks
+from vax.process.urls import clean_urls
 
 
 def process_location(df: pd.DataFrame, monotonic_check_skip: list = [], anomaly_check_skip: list = []) -> pd.DataFrame:
@@ -35,4 +36,6 @@ def process_location(df: pd.DataFrame, monotonic_check_skip: list = [], anomaly_
     df = df.applymap(lambda x: x.strip() if isinstance(x, str) else x)
     # Date format
     df = df.assign(date=df.date.dt.strftime("%Y-%m-%d"))
+    # Clean URLs
+    df = clean_urls(df)
     return df

--- a/scripts/scripts/vaccinations/src/vax/process/urls.py
+++ b/scripts/scripts/vaccinations/src/vax/process/urls.py
@@ -1,0 +1,22 @@
+"""Clean and process url fields."""
+import pandas as pd
+
+
+regex_twitter = (
+    r"(http(?:s)?:\/\/(?:www\.)?twitter\.com\/[a-zA-Z0-9_]+/status/[0-9]+)(\?s=\d+|/photo/\d+)?"
+)
+regex_facebook = (
+    r"(http(?:s)?:\/\/(?:(?:www|m)\.)?)(facebook\.com\/[a-zA-Z0-9_\.]+\/(?:photos|posts|videos|)\/[0-9\/\.pcba]+)"
+    r"((?:\?|__tn__).+)?"
+)
+
+def clean_urls(df: pd.DataFrame) -> pd.DataFrame:
+    # Twitter
+    msk = df.source_url.str.match(regex_twitter)
+    df.loc[msk, "source_url"] = df.loc[msk, "source_url"].str.extract(regex_twitter)[0]
+
+    # Facebook
+    msk = df.source_url.str.fullmatch(regex_facebook)
+    df.loc[msk, "source_url"] =  "https://www." + df.loc[msk, "source_url"].str.extract(regex_facebook)[1]
+
+    return df


### PR DESCRIPTION
Some portals, like Twitter and Facebook, add some suffixes to the URL that do not add direct value to the URL when tracking sources.

For instance: `https://twitter.com/GovernAndorra/status/1378732225571749892?s=20`, does add "?s=20" .

This PR cleans/standardizes Facebook and Twitter URL and opens the road to do similar with other portals.