### PR TITLE
Update Serbia.csv

### DIFF
--- a/public/data/vaccinations/country_data/Serbia.csv
+++ b/public/data/vaccinations/country_data/Serbia.csv
@@ -87,4 +87,5 @@ Serbia,2021-05-12,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinopharm/Beijing, Sputn
 Serbia,2021-05-15,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinopharm/Beijing, Sputnik V",https://vakcinacija.gov.rs/,4021493,2278826,1742667
 Serbia,2021-05-16,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinopharm/Beijing, Sputnik V",https://vakcinacija.gov.rs/,4038392,2286468,1751924
 Serbia,2021-05-17,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinopharm/Beijing, Sputnik V",https://vakcinacija.gov.rs/,4076567,2304204,1772363
+Serbia,2021-05-18,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinopharm/Beijing, Sputnik V",https://vakcinacija.gov.rs/,4128263,2320325,1807938
 Serbia,2021-05-19,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinopharm/Beijing, Sputnik V",https://vakcinacija.gov.rs/,4184634,2338805,1845829


### PR DESCRIPTION
This PR adds vaccination data for Serbia for May 18th 2021 which was not included. Since I feared that you might not include it, I have created a snapshot this morning when you could still see this data: http://archive.today/ehF8Z See also [Google cache](https://webcache.googleusercontent.com/search?q=cache:q0T3INsrO_IJ:https://vakcinacija.gov.rs/+&cd=1&hl=en&ct=clnk&gl=rs) (its [snapshot](http://archive.today/ybfHf)) for verification.