### PR TITLE
Update Azerbaijan vaccine list

### DIFF
--- a/scripts/scripts/vaccinations/output/Azerbaijan.csv
+++ b/scripts/scripts/vaccinations/output/Azerbaijan.csv
@@ -56,8 +56,9 @@ Azerbaijan,2021-05-13,"Oxford/AstraZeneca, Sinovac",https://koronavirusinfo.az,1
 Azerbaijan,2021-05-14,"Oxford/AstraZeneca, Sinovac",https://koronavirusinfo.az,1761632,1022479,739153
 Azerbaijan,2021-05-15,"Oxford/AstraZeneca, Sinovac",https://koronavirusinfo.az,1777426,1026376,751050
 Azerbaijan,2021-05-16,"Oxford/AstraZeneca, Sinovac",https://koronavirusinfo.az,1795049,1030831,764218
-Azerbaijan,2021-05-18,"Oxford/AstraZeneca, Sinovac",https://koronavirusinfo.az,1834657,1042781,791876
-Azerbaijan,2021-05-19,"Oxford/AstraZeneca, Sinovac",https://koronavirusinfo.az,1863292,1054414,808878
-Azerbaijan,2021-05-20,"Oxford/AstraZeneca, Sinovac",https://koronavirusinfo.az,1891703,1068493,823210
-Azerbaijan,2021-05-21,"Oxford/AstraZeneca, Sinovac",https://koronavirusinfo.az,1924805,1089886,834919
-Azerbaijan,2021-05-22,"Oxford/AstraZeneca, Sinovac",https://koronavirusinfo.az,1961563,1115044,846519
+Azerbaijan,2021-05-18,"Oxford/AstraZeneca, Sinovac, Sputnik V",https://koronavirusinfo.az,1834657,1042781,791876
+Azerbaijan,2021-05-19,"Oxford/AstraZeneca, Sinovac, Sputnik V",https://koronavirusinfo.az,1863292,1054414,808878
+Azerbaijan,2021-05-20,"Oxford/AstraZeneca, Sinovac, Sputnik V",https://koronavirusinfo.az,1891703,1068493,823210
+Azerbaijan,2021-05-21,"Oxford/AstraZeneca, Sinovac, Sputnik V",https://koronavirusinfo.az,1924805,1089886,834919
+Azerbaijan,2021-05-22,"Oxford/AstraZeneca, Sinovac, Sputnik V",https://koronavirusinfo.az,1961563,1115044,846519
+

--- a/scripts/scripts/vaccinations/src/vax/incremental/azerbaijan.py
+++ b/scripts/scripts/vaccinations/src/vax/incremental/azerbaijan.py
@@ -76,7 +76,7 @@ def enrich_location(ds: pd.Series) -> pd.Series:
 
 
 def enrich_vaccine(ds: pd.Series) -> pd.Series:
-    return enrich_data(ds, "vaccine", "Oxford/AstraZeneca, Sinovac")
+    return enrich_data(ds, "vaccine", "Oxford/AstraZeneca, Sinovac, Sputnik V")
 
 
 def enrich_source(ds: pd.Series, source: str) -> pd.Series:


### PR DESCRIPTION
Update Azerbaijan vaccine list
Source : https://menafn.com/1102092247/Azerbaijan-to-start-Sputnik-V-coronavirus-vaccination