### PR TITLE
Update Sri Lanka vaccine list

### DIFF
--- a/scripts/scripts/vaccinations/output/Sri Lanka.csv
+++ b/scripts/scripts/vaccinations/output/Sri Lanka.csv
@@ -71,18 +71,19 @@ Sri Lanka,2021-05-02,"Oxford/AstraZeneca, Sinopharm/Beijing",1016195,928107,http
 Sri Lanka,2021-05-03,"Oxford/AstraZeneca, Sinopharm/Beijing",1024978,928107,https://www.epid.gov.lk/web/images/pdf/corona_virus_report/sitrep-sl-en-03-05_10_21.pdf,96871
 Sri Lanka,2021-05-04,"Oxford/AstraZeneca, Sinopharm/Beijing",1048113,928107,https://www.epid.gov.lk/web/images/pdf/corona_virus_report/sitrep-sl-en-04-05_10_21.pdf,120006
 Sri Lanka,2021-05-05,"Oxford/AstraZeneca, Sinopharm/Beijing",1069828,928107,https://www.epid.gov.lk/web/images/pdf/corona_virus_report/sitrep-sl-en-05-05_10_21.pdf,141721
-Sri Lanka,2021-05-06,"Oxford/AstraZeneca, Sinopharm/Beijing",1088093,928107,https://www.epid.gov.lk/web/images/pdf/corona_virus_report/sitrep-sl-en-06-05_10_21.pdf,159986
-Sri Lanka,2021-05-07,"Oxford/AstraZeneca, Sinopharm/Beijing",1105342,928107,https://www.epid.gov.lk/web/images/pdf/corona_virus_report/sitrep-sl-en-07-05_10_21.pdf,177235
-Sri Lanka,2021-05-09,"Oxford/AstraZeneca, Sinopharm/Beijing",1125740,928400,https://www.epid.gov.lk/web/images/pdf/corona_virus_report/sitrep-sl-en-09-05_10_21.pdf,197340
-Sri Lanka,2021-05-10,"Oxford/AstraZeneca, Sinopharm/Beijing",1130257,931276,https://www.epid.gov.lk/web/images/pdf/corona_virus_report/sitrep-sl-en-10-05_10_21.pdf,198981
-Sri Lanka,2021-05-11,"Oxford/AstraZeneca, Sinopharm/Beijing",1162770,948817,https://www.epid.gov.lk/web/images/pdf/corona_virus_report/sitrep-sl-en-11-05_10_21.pdf,213953
-Sri Lanka,2021-05-12,"Oxford/AstraZeneca, Sinopharm/Beijing",1220248,996445,https://www.epid.gov.lk/web/images/pdf/corona_virus_report/sitrep-sl-en-12-05_10_21.pdf,223803
-Sri Lanka,2021-05-13,"Oxford/AstraZeneca, Sinopharm/Beijing",1309840,1075848,https://www.epid.gov.lk/web/images/pdf/corona_virus_report/sitrep-sl-en-13-05_10_21.pdf,233992
-Sri Lanka,2021-05-14,"Oxford/AstraZeneca, Sinopharm/Beijing",1384079,1140122,https://www.epid.gov.lk/web/images/pdf/corona_virus_report/sitrep-sl-en-14-05_10_21.pdf,243957
-Sri Lanka,2021-05-16,"Oxford/AstraZeneca, Sinopharm/Beijing",1541761,1273861,https://www.epid.gov.lk/web/images/pdf/corona_virus_report/sitrep-sl-en-16-05_10_21.pdf,267900
-Sri Lanka,2021-05-17,"Oxford/AstraZeneca, Sinopharm/Beijing",1570070,1300558,https://www.epid.gov.lk/web/images/pdf/corona_virus_report/sitrep-sl-en-17-05_10_21.pdf,269512
-Sri Lanka,2021-05-18,"Oxford/AstraZeneca, Sinopharm/Beijing",1644957,1350065,https://www.epid.gov.lk/web/images/pdf/corona_virus_report/sitrep-sl-en-18-05_10_21.pdf,294892
-Sri Lanka,2021-05-19,"Oxford/AstraZeneca, Sinopharm/Beijing",1683203,1383082,https://www.epid.gov.lk/web/images/pdf/corona_virus_report/sitrep-sl-en-19-05_10_21.pdf,300121
-Sri Lanka,2021-05-20,"Oxford/AstraZeneca, Sinopharm/Beijing",1707323,1399927,https://www.epid.gov.lk/web/images/pdf/corona_virus_report/sitrep-sl-en-20-05_10_21.pdf,307396
-Sri Lanka,2021-05-21,"Oxford/AstraZeneca, Sinopharm/Beijing",1726749,1410615,https://www.epid.gov.lk/web/images/pdf/corona_virus_report/sitrep-sl-en-21-05_10_21.pdf,316134
-Sri Lanka,2021-05-22,"Oxford/AstraZeneca, Sinopharm/Beijing",1749366,1426735,https://www.epid.gov.lk/web/images/pdf/corona_virus_report/sitrep-sl-en-22-05_10_21.pdf,322631
+Sri Lanka,2021-05-06,"Oxford/AstraZeneca, Sinopharm/Beijing, Sputnik V",1088093,928107,https://www.epid.gov.lk/web/images/pdf/corona_virus_report/sitrep-sl-en-06-05_10_21.pdf,159986
+Sri Lanka,2021-05-07,"Oxford/AstraZeneca, Sinopharm/Beijing, Sputnik V",1105342,928107,https://www.epid.gov.lk/web/images/pdf/corona_virus_report/sitrep-sl-en-07-05_10_21.pdf,177235
+Sri Lanka,2021-05-09,"Oxford/AstraZeneca, Sinopharm/Beijing, Sputnik V",1125740,928400,https://www.epid.gov.lk/web/images/pdf/corona_virus_report/sitrep-sl-en-09-05_10_21.pdf,197340
+Sri Lanka,2021-05-10,"Oxford/AstraZeneca, Sinopharm/Beijing, Sputnik V",1130257,931276,https://www.epid.gov.lk/web/images/pdf/corona_virus_report/sitrep-sl-en-10-05_10_21.pdf,198981
+Sri Lanka,2021-05-11,"Oxford/AstraZeneca, Sinopharm/Beijing, Sputnik V",1162770,948817,https://www.epid.gov.lk/web/images/pdf/corona_virus_report/sitrep-sl-en-11-05_10_21.pdf,213953
+Sri Lanka,2021-05-12,"Oxford/AstraZeneca, Sinopharm/Beijing, Sputnik V",1220248,996445,https://www.epid.gov.lk/web/images/pdf/corona_virus_report/sitrep-sl-en-12-05_10_21.pdf,223803
+Sri Lanka,2021-05-13,"Oxford/AstraZeneca, Sinopharm/Beijing, Sputnik V",1309840,1075848,https://www.epid.gov.lk/web/images/pdf/corona_virus_report/sitrep-sl-en-13-05_10_21.pdf,233992
+Sri Lanka,2021-05-14,"Oxford/AstraZeneca, Sinopharm/Beijing, Sputnik V",1384079,1140122,https://www.epid.gov.lk/web/images/pdf/corona_virus_report/sitrep-sl-en-14-05_10_21.pdf,243957
+Sri Lanka,2021-05-16,"Oxford/AstraZeneca, Sinopharm/Beijing, Sputnik V",1541761,1273861,https://www.epid.gov.lk/web/images/pdf/corona_virus_report/sitrep-sl-en-16-05_10_21.pdf,267900
+Sri Lanka,2021-05-17,"Oxford/AstraZeneca, Sinopharm/Beijing, Sputnik V",1570070,1300558,https://www.epid.gov.lk/web/images/pdf/corona_virus_report/sitrep-sl-en-17-05_10_21.pdf,269512
+Sri Lanka,2021-05-18,"Oxford/AstraZeneca, Sinopharm/Beijing, Sputnik V",1644957,1350065,https://www.epid.gov.lk/web/images/pdf/corona_virus_report/sitrep-sl-en-18-05_10_21.pdf,294892
+Sri Lanka,2021-05-19,"Oxford/AstraZeneca, Sinopharm/Beijing, Sputnik V",1683203,1383082,https://www.epid.gov.lk/web/images/pdf/corona_virus_report/sitrep-sl-en-19-05_10_21.pdf,300121
+Sri Lanka,2021-05-20,"Oxford/AstraZeneca, Sinopharm/Beijing, Sputnik V",1707323,1399927,https://www.epid.gov.lk/web/images/pdf/corona_virus_report/sitrep-sl-en-20-05_10_21.pdf,307396
+Sri Lanka,2021-05-21,"Oxford/AstraZeneca, Sinopharm/Beijing, Sputnik V",1726749,1410615,https://www.epid.gov.lk/web/images/pdf/corona_virus_report/sitrep-sl-en-21-05_10_21.pdf,316134
+Sri Lanka,2021-05-22,"Oxford/AstraZeneca, Sinopharm/Beijing, Sputnik V",1749366,1426735,https://www.epid.gov.lk/web/images/pdf/corona_virus_report/sitrep-sl-en-22-05_10_21.pdf,322631
+

--- a/scripts/scripts/vaccinations/src/vax/incremental/sri_lanka.py
+++ b/scripts/scripts/vaccinations/src/vax/incremental/sri_lanka.py
@@ -63,7 +63,7 @@ def enrich_location(ds: pd.Series) -> pd.Series:
 
 
 def enrich_vaccine(ds: pd.Series) -> pd.Series:
-    return enrich_data(ds, "vaccine", "Oxford/AstraZeneca, Sinopharm/Beijing")
+    return enrich_data(ds, "vaccine", "Oxford/AstraZeneca, Sinopharm/Beijing, Sputnik V")
 
 
 def pipeline(ds: pd.Series) -> pd.Series:


### PR DESCRIPTION
Update Sri Lanka vaccine list
Source : https://www.newindianexpress.com/world/2021/may/06/sri-lanka-rolls-out-russias-sputnik-v-covid-vaccine-2299159.html
