### PR TITLE
Fix Typo on Taiwan 2021-05-21 Vaccination Data

### DIFF
--- a/public/data/vaccinations/country_data/Taiwan.csv
+++ b/public/data/vaccinations/country_data/Taiwan.csv
@@ -53,4 +53,4 @@ Taiwan,2021-05-17,Oxford/AstraZeneca,https://www.cdc.gov.tw/Category/Page/9jFXNb
 Taiwan,2021-05-18,Oxford/AstraZeneca,https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,245008,,
 Taiwan,2021-05-19,Oxford/AstraZeneca,https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,264589,,
 Taiwan,2021-05-20,Oxford/AstraZeneca,https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,281647,,
-Taiwan,2021-05-21,Oxford/AstraZeneca,https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,2998442,,
+Taiwan,2021-05-21,Oxford/AstraZeneca,https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,299844,,


### PR DESCRIPTION
https://www.cdc.gov.tw/File/Get/a42bI1za87NU3AKC-MVCgA

Taiwan CDC only record 299,844 total vaccination on 21 May. In the previous (unfixed data), the git data said that the total vaccination is 2,998,442