### PR TITLE
Typo, extra '2' removed, in Taiwan vaccination data

### DIFF
--- a/public/data/vaccinations/country_data/Taiwan.csv
+++ b/public/data/vaccinations/country_data/Taiwan.csv
@@ -53,4 +53,4 @@ Taiwan,2021-05-17,Oxford/AstraZeneca,https://www.cdc.gov.tw/Category/Page/9jFXNb
 Taiwan,2021-05-18,Oxford/AstraZeneca,https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,245008,,
 Taiwan,2021-05-19,Oxford/AstraZeneca,https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,264589,,
 Taiwan,2021-05-20,Oxford/AstraZeneca,https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,281647,,
-Taiwan,2021-05-21,Oxford/AstraZeneca,https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,2998442,,
+Taiwan,2021-05-21,Oxford/AstraZeneca,https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,299844,,


### PR DESCRIPTION
Corrected from: https://www.cdc.gov.tw/File/Get/a42bI1za87NU3AKC-MVCgA

"累計接種 299,844 人次" => "299,844 cumulative deliveries" (where '人' means 'people')