### PR TITLE
VAX: Add second dose information Australia

### DIFF
--- a/scripts/scripts/vaccinations/output/Australia.csv
+++ b/scripts/scripts/vaccinations/output/Australia.csv
@@ -1,32 +1,32 @@
-date,total_vaccinations,people_vaccinated,people_fully_vaccinated,vaccine,location,source_url
-2021-02-15,0.0,,,Pfizer/BioNTech,Australia,https://covidlive.com.au/vaccinations
-2021-02-16,0.0,,,Pfizer/BioNTech,Australia,https://covidlive.com.au/vaccinations
-2021-02-17,0.0,,,Pfizer/BioNTech,Australia,https://covidlive.com.au/vaccinations
-2021-02-18,0.0,,,Pfizer/BioNTech,Australia,https://covidlive.com.au/vaccinations
-2021-02-19,0.0,,,Pfizer/BioNTech,Australia,https://covidlive.com.au/vaccinations
-2021-02-20,0.0,,,Pfizer/BioNTech,Australia,https://covidlive.com.au/vaccinations
-2021-02-21,0.0,,,Pfizer/BioNTech,Australia,https://covidlive.com.au/vaccinations
-2021-02-22,20.0,,,Pfizer/BioNTech,Australia,https://covidlive.com.au/vaccinations
-2021-02-23,2879.0,,,Pfizer/BioNTech,Australia,https://covidlive.com.au/vaccinations
-2021-02-24,6908.0,,,Pfizer/BioNTech,Australia,https://covidlive.com.au/vaccinations
-2021-02-25,17500.0,,,Pfizer/BioNTech,Australia,https://covidlive.com.au/vaccinations
-2021-02-26,25000.0,,,Pfizer/BioNTech,Australia,https://covidlive.com.au/vaccinations
-2021-02-27,30000.0,,,Pfizer/BioNTech,Australia,https://covidlive.com.au/vaccinations
-2021-02-28,31894.0,,,Pfizer/BioNTech,Australia,https://covidlive.com.au/vaccinations
-2021-03-01,33702.0,,,Pfizer/BioNTech,Australia,https://covidlive.com.au/vaccinations
-2021-03-02,41907.0,,,Pfizer/BioNTech,Australia,https://covidlive.com.au/vaccinations
-2021-03-03,50840.0,,,Pfizer/BioNTech,Australia,https://covidlive.com.au/vaccinations
-2021-03-04,61008.0,,,Pfizer/BioNTech,Australia,https://covidlive.com.au/vaccinations
-2021-03-05,71867.0,,,Pfizer/BioNTech,Australia,https://covidlive.com.au/vaccinations
-2021-03-06,76940.0,,,Pfizer/BioNTech,Australia,https://covidlive.com.au/vaccinations
-2021-03-07,81345.0,,,Pfizer/BioNTech,Australia,https://covidlive.com.au/vaccinations
-2021-03-08,86369.0,,,"Oxford/AstraZeneca, Pfizer/BioNTech",Australia,https://covidlive.com.au/vaccinations
-2021-03-09,94908.0,,,"Oxford/AstraZeneca, Pfizer/BioNTech",Australia,https://covidlive.com.au/vaccinations
-2021-03-10,106200.0,,,"Oxford/AstraZeneca, Pfizer/BioNTech",Australia,https://covidlive.com.au/vaccinations
-2021-03-11,125000.0,,,"Oxford/AstraZeneca, Pfizer/BioNTech",Australia,https://covidlive.com.au/vaccinations
-2021-03-12,135103.0,,,"Oxford/AstraZeneca, Pfizer/BioNTech",Australia,https://covidlive.com.au/vaccinations
-2021-03-13,159294.0,,,"Oxford/AstraZeneca, Pfizer/BioNTech",Australia,https://covidlive.com.au/vaccinations
-2021-03-14,162551.0,,,"Oxford/AstraZeneca, Pfizer/BioNTech",Australia,https://covidlive.com.au/vaccinations
+date,total_vaccinations,people_fully_vaccinated,people_vaccinated,vaccine,location,source_url
+2021-02-15,0.0,0,0.0,Pfizer/BioNTech,Australia,https://covidlive.com.au/vaccinations
+2021-02-16,0.0,0,0.0,Pfizer/BioNTech,Australia,https://covidlive.com.au/vaccinations
+2021-02-17,0.0,0,0.0,Pfizer/BioNTech,Australia,https://covidlive.com.au/vaccinations
+2021-02-18,0.0,0,0.0,Pfizer/BioNTech,Australia,https://covidlive.com.au/vaccinations
+2021-02-19,0.0,0,0.0,Pfizer/BioNTech,Australia,https://covidlive.com.au/vaccinations
+2021-02-20,0.0,0,0.0,Pfizer/BioNTech,Australia,https://covidlive.com.au/vaccinations
+2021-02-21,0.0,0,0.0,Pfizer/BioNTech,Australia,https://covidlive.com.au/vaccinations
+2021-02-22,20.0,0,20.0,Pfizer/BioNTech,Australia,https://covidlive.com.au/vaccinations
+2021-02-23,2879.0,0,2879.0,Pfizer/BioNTech,Australia,https://covidlive.com.au/vaccinations
+2021-02-24,6908.0,0,6908.0,Pfizer/BioNTech,Australia,https://covidlive.com.au/vaccinations
+2021-02-25,17500.0,0,17500.0,Pfizer/BioNTech,Australia,https://covidlive.com.au/vaccinations
+2021-02-26,25000.0,0,25000.0,Pfizer/BioNTech,Australia,https://covidlive.com.au/vaccinations
+2021-02-27,30000.0,0,30000.0,Pfizer/BioNTech,Australia,https://covidlive.com.au/vaccinations
+2021-02-28,31894.0,0,31894.0,Pfizer/BioNTech,Australia,https://covidlive.com.au/vaccinations
+2021-03-01,33702.0,0,33702.0,Pfizer/BioNTech,Australia,https://covidlive.com.au/vaccinations
+2021-03-02,41907.0,0,41907.0,Pfizer/BioNTech,Australia,https://covidlive.com.au/vaccinations
+2021-03-03,50840.0,0,50840.0,Pfizer/BioNTech,Australia,https://covidlive.com.au/vaccinations
+2021-03-04,61008.0,0,61008.0,Pfizer/BioNTech,Australia,https://covidlive.com.au/vaccinations
+2021-03-05,71867.0,0,71867.0,Pfizer/BioNTech,Australia,https://covidlive.com.au/vaccinations
+2021-03-06,76940.0,0,76940.0,Pfizer/BioNTech,Australia,https://covidlive.com.au/vaccinations
+2021-03-07,81345.0,0,81345.0,Pfizer/BioNTech,Australia,https://covidlive.com.au/vaccinations
+2021-03-08,86369.0,0,86369.0,"Oxford/AstraZeneca, Pfizer/BioNTech",Australia,https://covidlive.com.au/vaccinations
+2021-03-09,94908.0,0,94908.0,"Oxford/AstraZeneca, Pfizer/BioNTech",Australia,https://covidlive.com.au/vaccinations
+2021-03-10,106200.0,0,106200.0,"Oxford/AstraZeneca, Pfizer/BioNTech",Australia,https://covidlive.com.au/vaccinations
+2021-03-11,125000.0,0,125000.0,"Oxford/AstraZeneca, Pfizer/BioNTech",Australia,https://covidlive.com.au/vaccinations
+2021-03-12,135103.0,0,135103.0,"Oxford/AstraZeneca, Pfizer/BioNTech",Australia,https://covidlive.com.au/vaccinations
+2021-03-13,159294.0,0,159294.0,"Oxford/AstraZeneca, Pfizer/BioNTech",Australia,https://covidlive.com.au/vaccinations
+2021-03-14,162551.0,0,162551.0,"Oxford/AstraZeneca, Pfizer/BioNTech",Australia,https://covidlive.com.au/vaccinations
 2021-03-15,164781.0,,,"Oxford/AstraZeneca, Pfizer/BioNTech",Australia,https://covidlive.com.au/vaccinations
 2021-03-16,182437.0,,,"Oxford/AstraZeneca, Pfizer/BioNTech",Australia,https://covidlive.com.au/vaccinations
 2021-03-17,203557.0,,,"Oxford/AstraZeneca, Pfizer/BioNTech",Australia,https://covidlive.com.au/vaccinations
@@ -97,4 +97,4 @@ date,total_vaccinations,people_vaccinated,people_fully_vaccinated,vaccine,locati
 2021-05-21,3472874.0,,,"Oxford/AstraZeneca, Pfizer/BioNTech",Australia,https://covidlive.com.au/vaccinations
 2021-05-22,3562495.0,,,"Oxford/AstraZeneca, Pfizer/BioNTech",Australia,https://covidlive.com.au/vaccinations
 2021-05-23,3599964.0,,,"Oxford/AstraZeneca, Pfizer/BioNTech",Australia,https://covidlive.com.au/vaccinations
-2021-05-24,3613053.0,,,"Oxford/AstraZeneca, Pfizer/BioNTech",Australia,https://covidlive.com.au/vaccinations
+2021-05-24,3613053.0,416293.0,3196760.0,"Oxford/AstraZeneca, Pfizer/BioNTech",Australia,https://covidlive.com.au/vaccinations

--- a/scripts/scripts/vaccinations/src/vax/batch/australia.py
+++ b/scripts/scripts/vaccinations/src/vax/batch/australia.py
@@ -1,69 +1,80 @@
 import pandas as pd
 
 
-def read(source: str) -> pd.DataFrame:
-    return pd.read_json(source)
+class Australia:
 
+    def __init__(self, source_url: str, location: str, columns_rename: dict = None):
+        """Constructor.
 
-def filter_rows(df: pd.DataFrame) -> pd.DataFrame:
-    return df[(df.NAME == "Australia") & df.VACC_DOSE_CNT.notnull()]
+        Args:
+            source_url (str): Source data url
+            location (str): Location name
+            columns_rename (dict, optional): Maps original to new names. Defaults to None.
+        """
+        self.source_url = source_url
+        self.location = location
+        self.columns_rename = columns_rename
 
+    def read(self) -> pd.DataFrame:
+        return pd.read_json(self.source_url)
 
-def rename_columns(df: pd.DataFrame) -> pd.DataFrame:
-    return df[[
-        "REPORT_DATE",
-        "VACC_DOSE_CNT",
-        # "VACC_PEOPLE_CNT"
-    ]].rename(
-        columns={
-            "REPORT_DATE": "date",
-            "VACC_DOSE_CNT": "total_vaccinations",
-            # "VACC_PEOPLE_CNT": "people_vaccinated",
-        }
-    )
+    def pipe_filter_rows(self, df: pd.DataFrame) -> pd.DataFrame:
+        return df[(df.NAME == "Australia") & df.VACC_DOSE_CNT.notnull()]
 
+    def pipe_rename_columns(self, df: pd.DataFrame) -> pd.DataFrame:
+        return df[self.columns_rename.keys()].rename(columns=self.columns_rename)
 
-def enrich_vaccinations(df: pd.DataFrame) -> pd.DataFrame:
-    df = df.assign(
-        people_vaccinated=pd.NA,
-        people_fully_vaccinated=pd.NA,
-    )
-    return df
+    def pipe_people_full_vaccinated(self, df: pd.DataFrame) -> pd.DataFrame:
+        date_limit_low = "2021-03-15"
+        date_limit_up = "2021-05-24"
+        df.loc[(date_limit_low <= df.date) & (df.date < date_limit_up), "people_fully_vaccinated"] = pd.NA
+        df.loc[df.date < date_limit_low, "people_fully_vaccinated"] = 0
+        return df
 
+    def pipe_people_vaccinated(self, df: pd.DataFrame) -> pd.DataFrame:
+        df = df.assign(
+            people_vaccinated=df.total_vaccinations-df.people_fully_vaccinated,
+        )
+        return df
 
-def enrich_vaccine_name(df: pd.DataFrame) -> pd.DataFrame:
-    def _enrich_vaccine(date: str) -> str:
-        if date >= "2021-03-08":
-            return "Oxford/AstraZeneca, Pfizer/BioNTech"
-        return "Pfizer/BioNTech"
-    return df.assign(vaccine=df.date.astype(str).apply(_enrich_vaccine))
+    def pipe_vaccine(self, df: pd.DataFrame) -> pd.DataFrame:
+        def _enrich_vaccine(date: str) -> str:
+            if date >= "2021-03-08":
+                return "Oxford/AstraZeneca, Pfizer/BioNTech"
+            return "Pfizer/BioNTech"
+        return df.assign(vaccine=df.date.astype(str).apply(_enrich_vaccine))
 
+    def pipe_metadata(self, df: pd.DataFrame) -> pd.DataFrame:
+        return df.assign(
+            location="Australia",
+            source_url="https://covidlive.com.au/vaccinations"
+        )
 
-def enrich_columns(df: pd.DataFrame) -> pd.DataFrame:
-    return df.assign(
-        location="Australia",
-        source_url="https://covidlive.com.au/vaccinations"
-    )
+    def pipeline(self, df: pd.DataFrame) -> pd.DataFrame:
+        return (
+            df
+            .pipe(self.pipe_filter_rows)
+            .pipe(self.pipe_rename_columns)
+            .pipe(self.pipe_people_full_vaccinated)
+            .pipe(self.pipe_people_vaccinated)
+            .pipe(self.pipe_vaccine)
+            .pipe(self.pipe_metadata)
+            .sort_values("date")
+        )
 
-
-def pipeline(df: pd.DataFrame) -> pd.DataFrame:
-    return (
-        df
-        .pipe(filter_rows)
-        .pipe(rename_columns)
-        .pipe(enrich_vaccinations)
-        .pipe(enrich_vaccine_name)
-        .pipe(enrich_columns)
-        .sort_values("date")
-    )
+    def to_csv(self, paths):
+        """Generalized."""
+        df = self.read().pipe(self.pipeline)
+        df.to_csv(paths.tmp_vax_out(self.location), index=False)
 
 
 def main(paths):
-    source = "https://covidlive.com.au/covid-live.json"
-    destination = paths.tmp_vax_out("Australia")
-
-    read(source).pipe(pipeline).to_csv(destination, index=False)
-
-
-if __name__ == "__main__":
-    main()
+    Australia(
+        source_url="https://covidlive.com.au/covid-live.json",
+        location="Australia",
+        columns_rename={
+            "REPORT_DATE": "date",
+            "VACC_DOSE_CNT": "total_vaccinations",
+            "VACC_PEOPLE_CNT": "people_fully_vaccinated",
+        },
+    ).to_csv(paths)


### PR DESCRIPTION
Second dose information in Australia now available. Only getting second dose data starting from 24 May.

More context: 
- https://twitter.com/migga/status/1396741232408231938
- https://twitter.com/migga/status/1396339378629185536