### PR TITLE
VAX: Automate Antigua and Barbuda

### DIFF
--- a/scripts/scripts/vaccinations/output/Antigua and Barbuda.csv
+++ b/scripts/scripts/vaccinations/output/Antigua and Barbuda.csv
@@ -1,0 +1,19 @@
+location,date,vaccine,source_url,total_vaccinations,people_vaccinated,people_fully_vaccinated
+Antigua and Barbuda,2021-02-16,Oxford/AstraZeneca,https://www.facebook.com/investingforwellness/photos/1112443472528959,0,0,
+Antigua and Barbuda,2021-03-15,Oxford/AstraZeneca,https://www.facebook.com/investingforwellness/photos/1128577244248915,24164,24164,
+Antigua and Barbuda,2021-03-19,Oxford/AstraZeneca,https://www.facebook.com/investingforwellness/photos/a.259371477836167/1131568780616428/,25677,25677,
+Antigua and Barbuda,2021-03-25,Oxford/AstraZeneca,https://www.facebook.com/investingforwellness/photos/a.259371477836167/1135388016901171/,26424,26424,
+Antigua and Barbuda,2021-03-31,Oxford/AstraZeneca,https://www.facebook.com/investingforwellness/photos/a.259371477836167/1138342716605701/,26836,26836,
+Antigua and Barbuda,2021-04-03,Oxford/AstraZeneca,https://www.facebook.com/investingforwellness/photos/a.259371477836167/1139831226456850/,27032,27032,
+Antigua and Barbuda,2021-04-14,Oxford/AstraZeneca,https://www.facebook.com/investingforwellness/photos/a.259371477836167/1146840245755948/,27592,27592,
+Antigua and Barbuda,2021-04-16,Oxford/AstraZeneca,https://www.facebook.com/investingforwellness/photos/a.259371477836167/1147872885652684/,28414,28414,
+Antigua and Barbuda,2021-04-17,Oxford/AstraZeneca,https://www.facebook.com/investingforwellness/photos/a.259371477836167/1148691415570831/,28639,28639,
+Antigua and Barbuda,2021-04-22,Oxford/AstraZeneca,https://www.facebook.com/investingforwellness/photos/a.259371477836167/1151870888586217/,29754,29754,
+Antigua and Barbuda,2021-05-07,Oxford/AstraZeneca,https://www.facebook.com/investingforwellness/photos/pcb.1162231734216799/1162231244216848/,31085,31085,
+Antigua and Barbuda,2021-05-11,Oxford/AstraZeneca,https://www.facebook.com/investingforwellness/photos/pcb.1163324580774181/1163324470774192/,31262,31262,
+Antigua and Barbuda,2021-05-17,Oxford/AstraZeneca,https://www.facebook.com/investingforwellness/photos/pcb.1168194326953873/1168194280287211/,34441,31860,2581
+Antigua and Barbuda,2021-05-21,Oxford/AstraZeneca,https://www.facebook.com/investingforwellness/photos/a.274442642995717/1170044350102204/,39519,32469,7050
+Antigua and Barbuda,2021-05-25,Oxford/AstraZeneca,https://covid19.gov.ag,42009,32759,9250
+Antigua and Barbuda,2021-05-26,Oxford/AstraZeneca,https://www.facebook.com/investingforwellness/posts/1173570199749619,44230,32876,11354
+Antigua and Barbuda,2021-05-27,Oxford/AstraZeneca,https://www.facebook.com/investingforwellness/posts/1174079459698693?__cft__[0]=AZXkMWKx9Up7Ri9ZD85cXuVQEGAmr0QWoPf9aPKgL6xFwgLW9LPRyWzwXgBJSYGrQcggbclPwrGaxzmJrz_I_5u61D_Src-fEOIFxVNInf0KmD5sDbk9MM_83-axV1AwsLTlAiKhtxFs0diDF-ZVOLNh&__tn__=%2CO*F,45939,33024,12915
+Antigua and Barbuda,2021-05-29,Oxford/AstraZeneca,https://www.facebook.com/investingforwellness/photos/a.274442642995717/1175314882908484/?__tn__=%2CO*F,48347,33214,15133

--- a/scripts/scripts/vaccinations/src/vax/incremental/antigua_and_barbuda.py
+++ b/scripts/scripts/vaccinations/src/vax/incremental/antigua_and_barbuda.py
@@ -1,0 +1,102 @@
+import re
+
+import pandas as pd
+
+from vax.utils.utils import get_soup
+from vax.utils.incremental import clean_count, increment, enrich_data
+from vax.utils.dates import extract_clean_date
+
+
+class AntiguaBarbuda:
+
+    def __init__(self, source_url: str, location: str):
+        self.source_url = source_url
+        self.location = location
+        self.regex = {
+            "date": r'\[Updated on ([a-zA-Z]+ \d{1,2}, 202\d)\]'
+        }
+
+    def read(self) -> pd.DataFrame:
+        soup = get_soup(self.source_url)
+        return self.parse_data(soup)
+
+    def parse_data(self, soup):
+        dose1_elem, dose2_elem = self._get_elements(soup)
+        return pd.Series({
+            "date": self._parse_date(dose1_elem, dose2_elem),
+            "people_vaccinated": self._parse_metric(dose1_elem),
+            "people_fully_vaccinated": self._parse_metric(dose2_elem),
+        })
+
+    def _get_elements(self, soup):
+        # Get elements
+        h1 = soup.find_all("h1")
+        for h in h1:
+            text = h.text.strip()
+            if text == "Vaccinated Cases 1st Dose":
+                dose1_elem = h.parent
+            if text == "Vaccinated Cases 2nd Dose":
+                dose2_elem = h.parent
+        return dose1_elem, dose2_elem
+
+    def _parse_date(self, dose1_elem, dose2_elem):
+        date1_raw = dose1_elem.find("h2").text
+        date1 = extract_clean_date(date1_raw, self.regex["date"], "%B %d, %Y", minus_days=1)
+        date2_raw = dose2_elem.find("h2").text
+        date2 = extract_clean_date(date2_raw, self.regex["date"], "%B %d, %Y", minus_days=1)
+        if date1 == date2:
+            return date1
+        raise ValueError("Dates in first and second doses are not aligned")
+
+    def _parse_metric(self, elem):
+        elems = elem.find_all("div")
+        for elem in elems:
+            if "Total Vaccinated" in elem.text:
+                return clean_count(elem.find(class_="case-Number").text)
+
+    def pipe_people_vaccinated(self, ds: pd.Series) -> pd.Series:
+        total_vaccinations = ds.loc["people_vaccinated"] + ds.loc["people_fully_vaccinated"]
+        return enrich_data(ds, "total_vaccinations", total_vaccinations)
+
+    def pipe_location(self, ds: pd.Series) -> pd.Series:
+        return enrich_data(ds, "location", self.location)
+
+    def pipe_vaccine(self, ds: pd.Series) -> pd.Series:
+        return enrich_data(ds, "vaccine", "Oxford/AstraZeneca")
+
+    def pipe_source(self, ds: pd.Series) -> pd.Series:
+        return enrich_data(ds, "source_url", self.source_url)
+
+    def pipeline(self, df: pd.Series) -> pd.Series:
+        return (
+            df
+            .pipe(self.pipe_people_vaccinated)
+            .pipe(self.pipe_location)
+            .pipe(self.pipe_vaccine)
+            .pipe(self.pipe_source)
+        )
+
+    def to_csv(self, paths):
+        """Generalized."""
+        ds = self.read().pipe(self.pipeline)
+        increment(
+            paths=paths,
+            location=ds['location'],
+            total_vaccinations=ds['total_vaccinations'],
+            people_vaccinated=ds['people_vaccinated'],
+            people_fully_vaccinated=ds['people_fully_vaccinated'],
+            date=ds['date'],
+            source_url=ds['source_url'],
+            vaccine=ds['vaccine']
+        )
+
+
+def main(paths):
+    AntiguaBarbuda(
+        source_url="https://covid19.gov.ag",
+        location="Antigua and Barbuda",
+    ).to_csv(paths)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/scripts/vaccinations/src/vax/incremental/antigua_barbuda.py
+++ b/scripts/scripts/vaccinations/src/vax/incremental/antigua_barbuda.py
@@ -41,9 +41,13 @@ class AntiguaBarbuda:
 
     def _parse_date(self, dose1_elem, dose2_elem):
         date1_raw = dose1_elem.find("h2").text
-        date1 = extract_clean_date(date1_raw, self.regex["date"], "%B %d, %Y", minus_days=1)
+        date1 = extract_clean_date(
+            date1_raw, self.regex["date"], "%B %d, %Y", minus_days=1, lang="en"
+        )
         date2_raw = dose2_elem.find("h2").text
-        date2 = extract_clean_date(date2_raw, self.regex["date"], "%B %d, %Y", minus_days=1)
+        date2 = extract_clean_date(
+            date2_raw, self.regex["date"], "%B %d, %Y", minus_days=1, lang="en"
+        )
         if date1 == date2:
             return date1
         raise ValueError("Dates in first and second doses are not aligned")


### PR DESCRIPTION
Notes: 

- Data in automated source https://covid19.gov.ag was last updated on 2021-05-26. On the contrary, reports on Facebook have been updated in posterior dates 2021-05-27, 2021-05-28 and 2021-05-29.
- I have reached them to consult this.
- If automated source is eventually updated, but with less frequency, I still I think is OK to have this automated.