### PR TITLE
VAX: Add countries to WHO imports

### DIFF
--- a/scripts/scripts/vaccinations/output/Afghanistan.csv
+++ b/scripts/scripts/vaccinations/output/Afghanistan.csv
@@ -9,3 +9,4 @@ Afghanistan,2021-05-20,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinopharm/Beijing",
 Afghanistan,2021-05-24,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinopharm/Beijing",https://covid19.who.int/,573277,476367,96910
 Afghanistan,2021-05-26,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinopharm/Beijing",https://covid19.who.int/,590454,479372,111082
 Afghanistan,2021-05-27,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinopharm/Beijing",https://covid19.who.int/,593313,479574,113739
+Afghanistan,2021-05-30,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinopharm/Beijing",https://covid19.who.int/,600152,480226,119926

--- a/scripts/scripts/vaccinations/output/Angola.csv
+++ b/scripts/scripts/vaccinations/output/Angola.csv
@@ -12,3 +12,4 @@ Angola,2021-05-12,Oxford/AstraZeneca,https://covid19.who.int/,626572,586377,4019
 Angola,2021-05-18,Oxford/AstraZeneca,https://covid19.who.int/,681502,606287,75215
 Angola,2021-05-21,Oxford/AstraZeneca,https://covid19.who.int/,757535,630984,126551
 Angola,2021-05-26,Oxford/AstraZeneca,https://covid19.who.int/,859979,663049,196930
+Angola,2021-05-31,Oxford/AstraZeneca,https://covid19.who.int/,909215,679034,230181

--- a/scripts/scripts/vaccinations/output/Anguilla.csv
+++ b/scripts/scripts/vaccinations/output/Anguilla.csv
@@ -1,0 +1,12 @@
+location,date,vaccine,source_url,total_vaccinations,people_vaccinated,people_fully_vaccinated
+Anguilla,2021-02-04,Oxford/AstraZeneca,https://www.facebook.com/MinistryofHealthAnguilla/photos/pcb.1385492388472000/1385492311805341/,0,0,
+Anguilla,2021-02-13,Oxford/AstraZeneca,https://www.facebook.com/MinistryofHealthAnguilla/posts/1391067271247845,1341,1341,
+Anguilla,2021-02-14,Oxford/AstraZeneca,https://www.facebook.com/MinistryofHealthAnguilla/posts/1395958984092007,2762,2762,
+Anguilla,2021-02-26,Oxford/AstraZeneca,https://www.facebook.com/MinistryofHealthAnguilla/posts/1401018393586066,3929,3929,
+Anguilla,2021-03-09,Oxford/AstraZeneca,https://beatcovid19.ai/captacion-de-la-vacunacion-covid-19-el-ministerio-de-salud-pide-para-que-mas-personas-se-vacunen/,4700,4700,
+Anguilla,2021-03-13,Oxford/AstraZeneca,https://www.facebook.com/MinistryofHealthAnguilla/photos/1410852835935955,5000,5000,
+Anguilla,2021-03-19,Oxford/AstraZeneca,https://www.facebook.com/MinistryofHealthAnguilla/posts/1416076468746925,5348,5348,
+Anguilla,2021-04-12,Oxford/AstraZeneca,https://beatcovid19.ai/covid-19-update-scheduled-appointments-for-2nd-doses-of-covid-19-vaccine-to-begin-april-12th/,5835,5835,
+Anguilla,2021-04-22,Oxford/AstraZeneca,https://www.travelpulse.com/news/impacting-travel/new-covid-19-case-prompts-14-day-anguilla-closure.html,6898,6115,783
+Anguilla,2021-05-17,Oxford/AstraZeneca,https://www.facebook.com/MinistryofHealthAnguilla/photos/1458056911215547,13235,8811,4424
+Anguilla,2021-05-28,Oxford/AstraZeneca,https://covid19.who.int/,14443,9004,5439

--- a/scripts/scripts/vaccinations/output/British Virgin Islands.csv
+++ b/scripts/scripts/vaccinations/output/British Virgin Islands.csv
@@ -1,2 +1,3 @@
 location,date,vaccine,total_vaccinations,source_url,people_vaccinated,people_fully_vaccinated
 British Virgin Islands,2021-05-21,Oxford/AstraZeneca,15031,https://covid19.who.int/,11255,3776
+British Virgin Islands,2021-05-28,Oxford/AstraZeneca,16302,https://covid19.who.int/,11553,4749

--- a/scripts/scripts/vaccinations/output/Cameroon.csv
+++ b/scripts/scripts/vaccinations/output/Cameroon.csv
@@ -7,3 +7,4 @@ Cameroon,2021-05-18,"Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.who.
 Cameroon,2021-05-21,"Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.who.int/,50106,46658,3448
 Cameroon,2021-05-24,"Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.who.int/,57008,51925,5083
 Cameroon,2021-05-26,"Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.who.int/,64829,56583,8246
+Cameroon,2021-05-31,"Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.who.int/,75215,63404,11811

--- a/scripts/scripts/vaccinations/output/Central African Republic.csv
+++ b/scripts/scripts/vaccinations/output/Central African Republic.csv
@@ -1,2 +1,3 @@
 location,date,vaccine,total_vaccinations,source_url,people_vaccinated,people_fully_vaccinated
 Central African Republic,2021-05-12,"Covaxin, Oxford/AstraZeneca",667,https://covid19.who.int/,667,0
+Central African Republic,2021-05-31,"Covaxin, Oxford/AstraZeneca",18408,https://covid19.who.int/,17691,717

--- a/scripts/scripts/vaccinations/output/Comoros.csv
+++ b/scripts/scripts/vaccinations/output/Comoros.csv
@@ -4,3 +4,4 @@ Comoros,2021-05-12,"Covaxin, Oxford/AstraZeneca, Sinopharm/Beijing",https://covi
 Comoros,2021-05-18,"Covaxin, Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.who.int/,44975,43140,1835
 Comoros,2021-05-21,"Covaxin, Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.who.int/,58440,43140,15300
 Comoros,2021-05-26,"Covaxin, Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.who.int/,80023,43140,36883
+Comoros,2021-05-31,"Covaxin, Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.who.int/,83907,83907,0

--- a/scripts/scripts/vaccinations/output/Democratic Republic of Congo.csv
+++ b/scripts/scripts/vaccinations/output/Democratic Republic of Congo.csv
@@ -6,3 +6,4 @@ Democratic Republic of Congo,2021-05-18,Oxford/AstraZeneca,https://covid19.who.i
 Democratic Republic of Congo,2021-05-21,Oxford/AstraZeneca,https://covid19.who.int/,15436,15436,0
 Democratic Republic of Congo,2021-05-24,Oxford/AstraZeneca,https://covid19.who.int/,18204,18204,0
 Democratic Republic of Congo,2021-05-26,Oxford/AstraZeneca,https://covid19.who.int/,19597,19597,0
+Democratic Republic of Congo,2021-05-31,Oxford/AstraZeneca,https://covid19.who.int/,23197,23197,0

--- a/scripts/scripts/vaccinations/output/Egypt.csv
+++ b/scripts/scripts/vaccinations/output/Egypt.csv
@@ -9,3 +9,4 @@ Egypt,2021-05-22,"Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac, Sputnik V",htt
 Egypt,2021-05-23,"Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac, Sputnik V",https://covid19.who.int/,1962216,1653599,308617
 Egypt,2021-05-24,"Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac, Sputnik V",https://covid19.who.int/,2059987,1745841,314146
 Egypt,2021-05-25,"Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac, Sputnik V",https://covid19.who.int/,2128164,1812826,315338
+Egypt,2021-05-29,"Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac, Sputnik V",https://covid19.who.int/,2586274,2254371,331903

--- a/scripts/scripts/vaccinations/output/Ghana.csv
+++ b/scripts/scripts/vaccinations/output/Ghana.csv
@@ -13,3 +13,4 @@ Ghana,2021-04-15,Oxford/AstraZeneca,755686,755686,https://www.ghanahealthservice
 Ghana,2021-04-20,Oxford/AstraZeneca,842521,842521,https://www.ghanahealthservice.org/covid19/press-releases.php,0
 Ghana,2021-04-26,Oxford/AstraZeneca,846588,846588,https://www.ghanahealthservice.org/covid19/press-releases.php,0
 Ghana,2021-05-24,"Oxford/AstraZeneca, Sputnik V",847871,847871,https://covid19.who.int/,0
+Ghana,2021-05-31,"Oxford/AstraZeneca, Sputnik V",1228216,852047,https://covid19.who.int/,376169

--- a/scripts/scripts/vaccinations/output/Honduras.csv
+++ b/scripts/scripts/vaccinations/output/Honduras.csv
@@ -1,0 +1,12 @@
+location,date,vaccine,source_url,total_vaccinations,people_vaccinated,people_fully_vaccinated
+Honduras,2021-02-28,"Moderna, Oxford/AstraZeneca",https://www.elheraldo.hn/sucesos/1446200-466/honduras-vacuna-coronavirus-salud-israel,2684,2684,0
+Honduras,2021-03-16,"Moderna, Oxford/AstraZeneca",https://user-images.githubusercontent.com/79803615/111423040-4c2aad80-86b5-11eb-9e66-18c00bfc9d86.png,7100,7100,0
+Honduras,2021-03-17,"Moderna, Oxford/AstraZeneca",https://twitter.com/saludhn/status/1372661671156719618,28570,28570,0
+Honduras,2021-03-19,"Moderna, Oxford/AstraZeneca",https://www.tunota.com/cuatro-casos-graves-entre-mas-de-37-mil-empleados-de-salud-vacunados-contra-el-covid-19-reporta-honduras,37317,37317,0
+Honduras,2021-03-21,"Moderna, Oxford/AstraZeneca",https://www.laprensa.hn/honduras/1451346-410/honduras-cobertura-segunda-jornada-vacunacion-personal-salud-pandemia-covid,43073,43073,0
+Honduras,2021-04-03,"Moderna, Oxford/AstraZeneca",https://www.elheraldo.hn/pais/1454094-466/honduras-continua-rezagada-vacunas-anticovid-salud-,52772,52772,0
+Honduras,2021-04-09,"Moderna, Oxford/AstraZeneca",https://proceso.hn/honduras-a-la-zaga-en-vacunacion-en-ca/,57639,55000,2639
+Honduras,2021-05-15,"Moderna, Oxford/AstraZeneca",https://www.laprensa.hn/honduras/1464590-410/ya-van-mas-de-114000-personas-vacunadas-contra-el-covid-19-honduras-coronavirus-salud,114225,108538,5687
+Honduras,2021-05-21,"Johnson&Johnson, Moderna, Oxford/AstraZeneca, Sputnik V",https://ais.paho.org/imm/IM_DosisAdmin-Vacunacion.asp,163858,136476,27585
+Honduras,2021-05-25,"Johnson&Johnson, Moderna, Oxford/AstraZeneca, Sputnik V",https://www.facebook.com/saludhn/photos/a.433930676775387/1819615874873520/,208843,,
+Honduras,2021-05-28,"Johnson&Johnson, Moderna, Oxford/AstraZeneca, Sputnik V",https://covid19.who.int/,253832,209704,

--- a/scripts/scripts/vaccinations/output/Liberia.csv
+++ b/scripts/scripts/vaccinations/output/Liberia.csv
@@ -3,3 +3,4 @@ Liberia,2021-05-12,Oxford/AstraZeneca,36404,https://covid19.who.int/,36404,0
 Liberia,2021-05-21,Oxford/AstraZeneca,52446,https://covid19.who.int/,52446,0
 Liberia,2021-05-24,Oxford/AstraZeneca,53626,https://covid19.who.int/,53626,0
 Liberia,2021-05-26,Oxford/AstraZeneca,55690,https://covid19.who.int/,55690,0
+Liberia,2021-05-31,Oxford/AstraZeneca,56144,https://covid19.who.int/,56144,0

--- a/scripts/scripts/vaccinations/output/Madagascar.csv
+++ b/scripts/scripts/vaccinations/output/Madagascar.csv
@@ -4,3 +4,4 @@ Madagascar,2021-05-18,Oxford/AstraZeneca,3890,https://covid19.who.int/,3890,0
 Madagascar,2021-05-21,Oxford/AstraZeneca,13539,https://covid19.who.int/,13539,0
 Madagascar,2021-05-24,Oxford/AstraZeneca,17258,https://covid19.who.int/,17258,0
 Madagascar,2021-05-26,Oxford/AstraZeneca,21912,https://covid19.who.int/,21912,0
+Madagascar,2021-05-31,Oxford/AstraZeneca,36640,https://covid19.who.int/,36640,0

--- a/scripts/scripts/vaccinations/output/Mauritania.csv
+++ b/scripts/scripts/vaccinations/output/Mauritania.csv
@@ -7,3 +7,4 @@ Mauritania,2021-05-09,Sinopharm/Beijing,https://www.sante.gov.mr/wp-content/uplo
 Mauritania,2021-05-21,Sinopharm/Beijing,https://covid19.who.int/region/afro/country/mr,25741,19468,6273
 Mauritania,2021-05-23,Sinopharm/Beijing,https://www.sante.gov.mr/wp-content/uploads/2021/05/Mauritania-COVID-19-Situation-Report-2021-05-23FR.pdf,28382,22109,6273
 Mauritania,2021-05-26,"Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.who.int/,28770,22360,6410
+Mauritania,2021-05-31,"Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.who.int/,37331,30561,6770

--- a/scripts/scripts/vaccinations/output/Mauritius.csv
+++ b/scripts/scripts/vaccinations/output/Mauritius.csv
@@ -4,3 +4,4 @@ Mauritius,2021-02-01,Oxford/AstraZeneca,https://www.lemauricien.com/actualites/v
 Mauritius,2021-02-17,Oxford/AstraZeneca,https://defimedia.info/voyages-et-covid-19-les-etats-unis-exigent-une-grande-prudence-sur-maurice,3843,3843,
 Mauritius,2021-03-24,Oxford/AstraZeneca,https://www.mymauritius.travel/articles/117323-vaccinated-mauritius-track-achieve-herd-immunity,117323,117323,
 Mauritius,2021-05-12,"Covaxin, Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.who.int/,220646,212182,8464
+Mauritius,2021-05-31,"Covaxin, Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.who.int/,400801,232673,168128

--- a/scripts/scripts/vaccinations/output/Montserrat.csv
+++ b/scripts/scripts/vaccinations/output/Montserrat.csv
@@ -7,3 +7,4 @@ Montserrat,2021-03-31,Oxford/AstraZeneca,https://www.facebook.com/GIUMontserrat/
 Montserrat,2021-04-14,Oxford/AstraZeneca,https://www.facebook.com/GIUMontserrat/posts/878147146077962,1751,1284,467
 Montserrat,2021-04-21,Oxford/AstraZeneca,https://www.facebook.com/GIUMontserrat/posts/882138232345520,1909,1293,616
 Montserrat,2021-05-21,Oxford/AstraZeneca,https://covid19.who.int/,2428,1342,1086
+Montserrat,2021-05-28,Oxford/AstraZeneca,https://covid19.who.int/,2522,1358,1164

--- a/scripts/scripts/vaccinations/output/Mozambique.csv
+++ b/scripts/scripts/vaccinations/output/Mozambique.csv
@@ -4,3 +4,4 @@ Mozambique,2021-03-13,Sinopharm/Beijing,https://allafrica.com/stories/2021031609
 Mozambique,2021-03-23,Sinopharm/Beijing,https://allafrica.com/stories/202103230834.html,57305,57305,0
 Mozambique,2021-05-12,"Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.who.int/,355995,296983,59012
 Mozambique,2021-05-18,"Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.who.int/,393105,318548,74557
+Mozambique,2021-05-31,"Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.who.int/,394312,319511,74801

--- a/scripts/scripts/vaccinations/output/Sao Tome and Principe.csv
+++ b/scripts/scripts/vaccinations/output/Sao Tome and Principe.csv
@@ -4,3 +4,4 @@ Sao Tome and Principe,2021-03-22,Oxford/AstraZeneca,https://www.facebook.com/MSa
 Sao Tome and Principe,2021-03-29,Oxford/AstraZeneca,https://www.facebook.com/MSaudeSTeP/photos/pcb.3764121173707955/3764120233708049,9724,9724,0
 Sao Tome and Principe,2021-05-18,Oxford/AstraZeneca,https://covid19.who.int/,12374,12374,0
 Sao Tome and Principe,2021-05-26,Oxford/AstraZeneca,https://covid19.who.int/,14509,12374,2135
+Sao Tome and Principe,2021-05-31,Oxford/AstraZeneca,https://covid19.who.int/,18888,12374,6514

--- a/scripts/scripts/vaccinations/output/Senegal.csv
+++ b/scripts/scripts/vaccinations/output/Senegal.csv
@@ -72,3 +72,4 @@ Senegal,2021-05-13,Sinopharm/Beijing,https://twitter.com/MinisteredelaS1/status/
 Senegal,2021-05-21,Sinopharm/Beijing,https://covid19.who.int/,506388,437792,68596
 Senegal,2021-05-24,"Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.who.int/,511286,442133,69153
 Senegal,2021-05-26,"Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.who.int/,513332,444007,69325
+Senegal,2021-05-31,"Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.who.int/,522575,452735,69840

--- a/scripts/scripts/vaccinations/output/Sierra Leone.csv
+++ b/scripts/scripts/vaccinations/output/Sierra Leone.csv
@@ -1,0 +1,15 @@
+location,date,vaccine,source_url,total_vaccinations,people_vaccinated,people_fully_vaccinated
+Sierra Leone,2021-03-14,Oxford/AstraZeneca,https://www.rfi.fr/en/africa/20210316-sierra-leone-s-president-starts-covid-19-vaccination-campaign-with-his-own-jab,0,0,0
+Sierra Leone,2021-03-25,Oxford/AstraZeneca,https://www.facebook.com/mohsict/photos/pcb.1359260857768390/1359260657768410/,10673,10673,0
+Sierra Leone,2021-03-30,Oxford/AstraZeneca,https://www.facebook.com/mohsict/photos/pcb.1362532444107898/1362532254107917/,25836,25836,0
+Sierra Leone,2021-03-31,Oxford/AstraZeneca,https://www.facebook.com/mohsict/posts/1364398257254650,31889,31889,0
+Sierra Leone,2021-04-10,Oxford/AstraZeneca,https://www.facebook.com/mohsict/posts/1369862266708249,37680,37558,122
+Sierra Leone,2021-04-14,Oxford/AstraZeneca,https://www.facebook.com/mohsict/photos/pcb.1371908103170332/1371907936503682/,42419,41543,876
+Sierra Leone,2021-04-15,Oxford/AstraZeneca,https://www.facebook.com/mohsict/photos/pcb.1372607549767054/1372607036433772/,44347,42566,1781
+Sierra Leone,2021-04-25,Oxford/AstraZeneca,https://www.facebook.com/mohsict/photos/pcb.1379507252410417/1379506939077115/,57364,52076,5288
+Sierra Leone,2021-04-27,Oxford/AstraZeneca,https://www.facebook.com/mohsict/photos/pcb.1380804642280678/1380804212280721/,59316,53717,5599
+Sierra Leone,2021-04-29,Oxford/AstraZeneca,https://www.facebook.com/mohsict/photos/pcb.1381411242220018/1381410965553379/,59786,54084,5702
+Sierra Leone,2021-05-01,Oxford/AstraZeneca,https://www.facebook.com/mohsict/photos/pcb.1382684728759336/1382683268759482/,61107,55083,6024
+Sierra Leone,2021-05-05,Oxford/AstraZeneca,https://www.facebook.com/mohsict/photos/a.864847130543101/1385267811834361/,,56774,
+Sierra Leone,2021-05-08,Oxford/AstraZeneca,https://www.facebook.com/mohsict/photos/pcb.1387167548311054/1387167118311097/,64966,58250,6716
+Sierra Leone,2021-05-31,"Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.who.int/,79762,68882,10880

--- a/scripts/scripts/vaccinations/output/Sint Maarten (Dutch part).csv
+++ b/scripts/scripts/vaccinations/output/Sint Maarten (Dutch part).csv
@@ -2,3 +2,4 @@ location,date,vaccine,total_vaccinations,source_url,people_vaccinated,people_ful
 Sint Maarten (Dutch part),2021-05-07,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",24634,https://covid19.who.int/,14678,9956
 Sint Maarten (Dutch part),2021-05-14,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",26121,https://covid19.who.int/,15304,10817
 Sint Maarten (Dutch part),2021-05-21,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",27285,https://covid19.who.int/,15906,11379
+Sint Maarten (Dutch part),2021-05-28,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",29055,https://covid19.who.int/,17024,12031

--- a/scripts/scripts/vaccinations/output/Somalia.csv
+++ b/scripts/scripts/vaccinations/output/Somalia.csv
@@ -5,3 +5,4 @@ Somalia,2021-05-16,"Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac",https://covi
 Somalia,2021-05-24,"Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac",https://covid19.who.int/,125205,125205,0
 Somalia,2021-05-25,"Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac",https://covid19.who.int/,125582,125582,0
 Somalia,2021-05-27,"Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac",https://covid19.who.int/,129461,128519,942
+Somalia,2021-05-31,"Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac",https://covid19.who.int/,134133,129419,4714

--- a/scripts/scripts/vaccinations/output/South Sudan.csv
+++ b/scripts/scripts/vaccinations/output/South Sudan.csv
@@ -6,3 +6,4 @@ South Sudan,2021-05-18,Oxford/AstraZeneca,https://covid19.who.int/,6403,6403,0
 South Sudan,2021-05-21,Oxford/AstraZeneca,https://covid19.who.int/,7500,7500,0
 South Sudan,2021-05-24,Oxford/AstraZeneca,https://covid19.who.int/,7976,7976,0
 South Sudan,2021-05-26,Oxford/AstraZeneca,https://covid19.who.int/,8606,8606,0
+South Sudan,2021-05-31,Oxford/AstraZeneca,https://covid19.who.int/,9744,9744,0

--- a/scripts/scripts/vaccinations/output/Sudan.csv
+++ b/scripts/scripts/vaccinations/output/Sudan.csv
@@ -5,3 +5,4 @@ Sudan,2021-04-06,Oxford/AstraZeneca,https://www.facebook.com/FMOH.SUDAN/posts/28
 Sudan,2021-04-10,Oxford/AstraZeneca,https://www.facebook.com/FMOH.SUDAN/posts/2871606859778940,100010,100010,0
 Sudan,2021-04-23,Oxford/AstraZeneca,https://www.facebook.com/FMOH.SUDAN/posts/2880648948874731,140227,140227,0
 Sudan,2021-05-09,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinopharm/Beijing, Sinovac",https://covid19.who.int/,290500,204838,85662
+Sudan,2021-05-30,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinopharm/Beijing, Sinovac",https://covid19.who.int/,358236,320305,37931

--- a/scripts/scripts/vaccinations/output/Syria.csv
+++ b/scripts/scripts/vaccinations/output/Syria.csv
@@ -1,0 +1,4 @@
+location,date,vaccine,source_url,total_vaccinations,people_vaccinated,people_fully_vaccinated
+Syria,2021-03-01,Sputnik V,https://www.aljazeera.com/news/2021/3/17/syria-launches-covid-vaccination-drive-amid-economic-challenges,0,0,0
+Syria,2021-04-08,Sputnik V,http://www.xinhuanet.com/english/africa/2021-04/08/c_139867196.htm,2500,2500,0
+Syria,2021-05-27,"Oxford/AstraZeneca, Sinopharm/Beijing, Sputnik V",https://covid19.who.int/,24781,24781,0

--- a/scripts/scripts/vaccinations/output/Togo.csv
+++ b/scripts/scripts/vaccinations/output/Togo.csv
@@ -1,0 +1,9 @@
+location,date,vaccine,source_url,total_vaccinations,people_vaccinated,people_fully_vaccinated
+Togo,2021-03-09,Oxford/AstraZeneca,https://www.rfi.fr/fr/afrique/20210310-le-togo-lance-sa-campagne-de-vaccination-contre-le-covid-19,0,0,0
+Togo,2021-03-24,Oxford/AstraZeneca,https://www.republicoftogo.com/Toutes-les-rubriques/Sante/Plus-de-42.000-personnes-vaccinees,42092,42092,0
+Togo,2021-04-08,Oxford/AstraZeneca,https://www.republicoftogo.com/Toutes-les-rubriques/Sante/Accelerer-la-vaccination-est-une-necessite,82753,82753,0
+Togo,2021-04-13,Oxford/AstraZeneca,https://www.republicoftogo.com/Toutes-les-rubriques/Sante/Plus-de-100.000-personnes-deja-vaccinees,100000,100000,0
+Togo,2021-04-17,Oxford/AstraZeneca,https://www.republicoftogo.com/Toutes-les-rubriques/Sante/La-vaccination-de-masse-va-commencer,160000,160000,0
+Togo,2021-05-17,Oxford/AstraZeneca,https://www.republicoftogo.com/Toutes-les-rubriques/Sante/Tous-ensemble,276000,276000,0
+Togo,2021-05-26,Oxford/AstraZeneca,https://www.republicoftogo.com/Toutes-les-rubriques/Sante/Les-personnels-de-sante-proteges,304630,276000,28630
+Togo,2021-05-31,Oxford/AstraZeneca,https://covid19.who.int/,311938,270784,41154

--- a/scripts/scripts/vaccinations/output/Turks and Caicos Islands.csv
+++ b/scripts/scripts/vaccinations/output/Turks and Caicos Islands.csv
@@ -1,0 +1,10 @@
+location,date,vaccine,source_url,total_vaccinations,people_vaccinated,people_fully_vaccinated
+Turks and Caicos Islands,2021-01-10,Pfizer/BioNTech,https://www.visittci.com/travel-info/turks-and-caicos-coronavirus-covid-19-vaccine,0,0,
+Turks and Caicos Islands,2021-02-08,Pfizer/BioNTech,https://www.facebook.com/tcihealthpromotions/posts/1892840824219198,,6433,
+Turks and Caicos Islands,2021-03-14,Pfizer/BioNTech,https://www.facebook.com/tcihealthpromotions/photos/1923854537784493,,11283,
+Turks and Caicos Islands,2021-03-21,Pfizer/BioNTech,https://www.facebook.com/tcihealthpromotions/posts/1929025373934076,,12935,
+Turks and Caicos Islands,2021-03-28,Pfizer/BioNTech,https://www.facebook.com/tcihealthpromotions/posts/1933293346840612,,13841,
+Turks and Caicos Islands,2021-03-29,Pfizer/BioNTech,https://www.youtube.com/watch?v=N9-Kc2-CZdc,24300,14300,10000
+Turks and Caicos Islands,2021-04-11,Pfizer/BioNTech,https://www.facebook.com/tcihealthpromotions/photos/1945783578924922,25039,15039,10000
+Turks and Caicos Islands,2021-05-16,Pfizer/BioNTech,https://www.facebook.com/tcihealthpromotions/photos/1974299556073324,30760,20760,10000
+Turks and Caicos Islands,2021-05-28,Pfizer/BioNTech,https://covid19.who.int/,36170,20760,15410

--- a/scripts/scripts/vaccinations/output/Yemen.csv
+++ b/scripts/scripts/vaccinations/output/Yemen.csv
@@ -1,2 +1,3 @@
 location,date,vaccine,total_vaccinations,source_url,people_vaccinated,people_fully_vaccinated
 Yemen,2021-05-09,Oxford/AstraZeneca,18555,https://covid19.who.int/,18555,0
+Yemen,2021-05-29,Oxford/AstraZeneca,104070,https://covid19.who.int/,104070,0

--- a/scripts/scripts/vaccinations/src/vax/incremental/who.py
+++ b/scripts/scripts/vaccinations/src/vax/incremental/who.py
@@ -10,6 +10,8 @@ from vax.utils.who import VACCINES_WHO_MAPPING
 COUNTRIES = {
     "Afghanistan": "Afghanistan",
     "Angola": "Angola",
+    "Anguilla": "Anguilla",
+    "Belarus": "Belarus",
     "Benin": "Benin",
     "Bonaire, Sint Eustatius and Saba": "Bonaire Sint Eustatius and Saba",
     "British Virgin Islands": "British Virgin Islands",
@@ -21,7 +23,9 @@ COUNTRIES = {
     "Democratic Republic of the Congo": "Democratic Republic of Congo",
     "Djibouti": "Djibouti",
     "Egypt": "Egypt",
+    "Ghana": "Ghana",
     "Guinea-Bissau": "Guinea-Bissau",
+    "Honduras": "Honduras",
     "Iran (Islamic Republic of)": "Iran",
     "Ireland": "Ireland",
     "Jamaica": "Jamaica",
@@ -31,32 +35,28 @@ COUNTRIES = {
     "Madagascar": "Madagascar",
     "Mauritania": "Mauritania",
     "Mauritius": "Mauritius",
+    "Montserrat": "Montserrat",
     "Mozambique": "Mozambique",
     "Myanmar": "Myanmar",
     "Nicaragua": "Nicaragua",
     "Niger": "Niger",
+    "Oman": "Oman",
     "Papua New Guinea": "Papua New Guinea",
     "Rwanda": "Rwanda",
     "Sao Tome and Principe": "Sao Tome and Principe",
     "Senegal": "Senegal",
+    "Sierra Leone": "Sierra Leone",
     "Sint Maarten": "Sint Maarten (Dutch part)",
     "Somalia": "Somalia",
     "South Sudan": "South Sudan",
     "Sudan": "Sudan",
+    "Syrian Arab Republic": "Syria",
     "Tajikistan": "Tajikistan",
     "Timor-Leste": "Timor",
-    "Turkmenistan": "Turkmenistan",
-    "Yemen": "Yemen",
-    "Belarus": "Belarus",
-    "Oman": "Oman",
-    "Montserrat": "Montserrat",
-    "Ghana": "Ghana",
-    "Sierra Leone": "Sierra Leone",
-    "Turks and Caicos Islands": "Turks and Caicos Islands",
-    "Anguilla": "Anguilla",
-    "Honduras": "Honduras",
-    "Syrian Arab Republic": "Syria",
     "Togo": "Togo",
+    "Turkmenistan": "Turkmenistan",
+    "Turks and Caicos Islands": "Turks and Caicos Islands",
+    "Yemen": "Yemen",
 }
 
 
@@ -136,7 +136,7 @@ def calculate_metrics(df: pd.DataFrame) -> pd.DataFrame:
 
 
 def increment_countries(df: pd.DataFrame, paths):
-    for row in df.iterrows():
+    for row in df.sort_values("COUNTRY").iterrows():
         row = row[1]
         print(row["COUNTRY"])        
         cond = row[["PERSONS_VACCINATED_1PLUS_DOSE", "people_fully_vaccinated", "TOTAL_VACCINATIONS"]].isnull().all()

--- a/scripts/scripts/vaccinations/src/vax/incremental/who.py
+++ b/scripts/scripts/vaccinations/src/vax/incremental/who.py
@@ -51,6 +51,12 @@ COUNTRIES = {
     "Oman": "Oman",
     "Montserrat": "Montserrat",
     "Ghana": "Ghana",
+    "Sierra Leone": "Sierra Leone",
+    "Turks and Caicos Islands": "Turks and Caicos Islands",
+    "Anguilla": "Anguilla",
+    "Honduras": "Honduras",
+    "Syrian Arab Republic": "Syria",
+    "Togo": "Togo",
 }
 
 


### PR DESCRIPTION
Following countries:

- Sierra Leone
- Turks and Caicos Islands
- Anguilla
- Honduras
- Syria
- Togo

These countries were chosen based on the metric: `number of samples obtained so far / number of days of observation`