### PR TITLE
Update Tunisia on 03/06

### DIFF
--- a/public/data/vaccinations/country_data/Tunisia.csv
+++ b/public/data/vaccinations/country_data/Tunisia.csv
@@ -64,3 +64,4 @@ Tunisia,2021-05-29,"Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.co
 Tunisia,2021-05-30,"Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4182377398467999,942532,644138,298394
 Tunisia,2021-05-31,"Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4185228114849594,958951,654976,303975
 Tunisia,2021-06-01,"Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4188267321212340,983647,672600,311047
+Tunisia,2021-06-01,"Pfizer/BioNTech, Sinovac, Sputnik V,Oxford/AstraZeneca",https://www.facebook.com/186480324724413/posts/4194043443968061/


### PR DESCRIPTION
Tunisia reache 1051796 dose administrated
First dose : 728092
Second dose: 322894
Also tunisia start using astrazenca vaccine 
This the link for the update of 03/06:
https://www.facebook.com/186480324724413/posts/4194043443968061/