### PR TITLE
Update vaccinations-by-manufacturer.csv

### DIFF
--- a/public/data/vaccinations/vaccinations-by-manufacturer.csv
+++ b/public/data/vaccinations/vaccinations-by-manufacturer.csv
@@ -5232,3 +5232,7 @@ Uruguay,2021-06-05,Sinovac,2267072
 Uruguay,2021-06-06,Oxford/AstraZeneca,42955
 Uruguay,2021-06-06,Pfizer/BioNTech,706146
 Uruguay,2021-06-06,Sinovac,2267987
+North Macedonia,2021-06-06,Pfizer/BioNTech,60526
+North Macedonia,2021-06-06,Sputnik V,45168
+North Macedonia,2021-06-06,Oxford/AstraZeneca,32875
+North Macedonia,2021-06-06,Sinopharm/Beijing,251705


### PR DESCRIPTION
North Macedonia:
source: http://iph.mk/wp-content/uploads/2021/06/info-COVID-19-do-06.06.2021.pdf

- 60.526 Pfizer/Biontech (43.441 people_vaccinated, 17.085 people_fully_vaccinated),
- 45.168 Sputnik V (22.875 people_vaccinated, 22.293 people_fully_vaccinated),
- 32.875 Oxford/AstraZeneca (32.843 people_vaccinated, 32 people_fully_vaccinated)
- 251.705 Sinopharm/Beijing (147.998 people_vaccinated, 103.707 people_fully_vaccinated).