### PR TITLE
Automate Jordan's Vaccination Numbers

### DIFF
--- a/scripts/scripts/vaccinations/README.md
+++ b/scripts/scripts/vaccinations/README.md
@@ -1,6 +1,6 @@
 # Vaccination update automation
 [![Python 3"](https://img.shields.io/badge/python-3.7|3.8|3.9-blue.svg?&logo=python&logoColor=yellow)](https://www.python.org/downloads/release/python-3)
-[![Contribubte](https://img.shields.io/badge/-contribute-0055ff)](CONTRIBUTE.md)
+[![Contribute](https://img.shields.io/badge/-contribute-0055ff)](CONTRIBUTE.md)
 [![Data](https://img.shields.io/badge/public-data-purple)](../../../public/data/)
 
 Vaccination data is updated on a daily basis. For some countries, the update is done by means of an automated process,
@@ -127,7 +127,7 @@ $ tox
 </details>
 
 ## 3. The data pipeline
-To update the data, prior to runing the code, make sure to correctly [set up the development environment](#development-environment).
+To update the data, prior to running the code, make sure to correctly [set up the development environment](#development-environment).
 
 ### Manual data updates
 
@@ -138,7 +138,7 @@ Check for new updates and manually add them in the internal spreadsheet:
 ### Automated process
 Once all manual processes have been finished, it  is time to leverage the tool `cowid-vax`. The automation step is
 further broken into 4 sub-steps, which we explain below. While these can all be run at once, we recommend running them
-one by one. Prior to runing these, make sure you are correctly using your [configuration file](#configuration-file).
+one by one. Prior to running these, make sure you are correctly using your [configuration file](#configuration-file).
 
 *Note*: you can use [vax_update.sh.template](vax_update.sh.template) as an example of how to run the data pipeline
 automated step.
@@ -263,7 +263,7 @@ $ cowid-vax get process
 
 ## 4. Other functions
 ### Tracking
-It is extremely usefull to get some insights on which data are we tracking (and which are we not). This can be done with
+It is extremely useful to get some insights on which data are we tracking (and which are we not). This can be done with
 the tool `cowid-vax-track`. Find below some use cases.
 
 *Note*: Use uption `--to-csv` to export results as csv files (a default filename is used).

--- a/scripts/scripts/vaccinations/output/Jordan.csv
+++ b/scripts/scripts/vaccinations/output/Jordan.csv
@@ -1,0 +1,22 @@
+location,date,vaccine,source_url,total_vaccinations,people_vaccinated,people_fully_vaccinated
+Jordan,2021-01-12,"Pfizer/BioNTech, Sinopharm/Beijing",https://petra.gov.jo/Include/InnerPage.jsp?ID=31830&lang=en&name=en_news,0,0,0
+Jordan,2021-01-23,"Pfizer/BioNTech, Sinopharm/Beijing",https://petra.gov.jo/Include/InnerPage.jsp?ID=31830&lang=en&name=en_news,30000,30000,0
+Jordan,2021-01-31,"Pfizer/BioNTech, Sinopharm/Beijing",https://twitter.com/PrimeMinistry/status/1355931355327197185,40000,40000,0
+Jordan,2021-02-22,"Pfizer/BioNTech, Sinopharm/Beijing",https://en.royanews.tv/news/25719/2021-02-22,80000,50000,30000
+Jordan,2021-02-25,"Pfizer/BioNTech, Sinopharm/Beijing",https://www.reuters.com/article/us-health-coronavirus-jordan/jordan-says-covid-19-vaccination-drive-to-accelerate-in-coming-weeks-idUSKBN2AP2VO,150000,,
+Jordan,2021-03-15,"Pfizer/BioNTech, Sinopharm/Beijing",http://www.jordantimes.com/news/local/155772-people-received-1st-dose-covid-vaccine-%E2%80%94-crisis-cell,204151,155772,48379
+Jordan,2021-03-17,"Pfizer/BioNTech, Sinopharm/Beijing",https://en.royanews.tv/news/26287/2021-03-17,241868,189456,52412
+Jordan,2021-03-21,"Pfizer/BioNTech, Sinopharm/Beijing",https://en.royanews.tv/news/26404/2021-03-21,272648,209278,63370
+Jordan,2021-03-24,"Pfizer/BioNTech, Sinopharm/Beijing",https://en.royanews.tv/news/26484/2021-03-24,320140,251197,68943
+Jordan,2021-03-30,"Pfizer/BioNTech, Sinopharm/Beijing",https://petra.gov.jo/Include/InnerPage.jsp?ID=33506&lang=en&name=en_news,409203,304946,104257
+Jordan,2021-04-07,"Pfizer/BioNTech, Sinopharm/Beijing",https://menafn.com/1101878861/Jordan-404912-people-receive-1st-dose-of-anti-COVID-19-vaccine-Crisis-cell?source=317,524533,404912,119621
+Jordan,2021-04-14,"Pfizer/BioNTech, Sinopharm/Beijing",https://petra.gov.jo/Include/InnerPage.jsp?ID=33858&lang=en&name=en_news,665226,543095,122131
+Jordan,2021-04-19,"Pfizer/BioNTech, Sinopharm/Beijing",https://petra.gov.jo/Include/InnerPage.jsp?ID=33968&lang=en&name=en_news,732052,607381,124671
+Jordan,2021-04-29,"Pfizer/BioNTech, Sinopharm/Beijing",https://petra.gov.jo/Include/InnerPage.jsp?ID=175868&lang=ar&name=news,919922,699328,220594
+Jordan,2021-05-04,"Pfizer/BioNTech, Sinopharm/Beijing",https://www.facebook.com/ncscmjordan/photos/a.388629101483029/1436628866683042,1091048,805020,286028
+Jordan,2021-05-18,"Pfizer/BioNTech, Sinopharm/Beijing",https://www.facebook.com/ncscmjordan/photos/a.388629101483029/1446122289067033/,1419950,1034808,385142
+Jordan,2021-05-26,"Pfizer/BioNTech, Sinopharm/Beijing",https://www.almamlakatv.com/news/63858-%D8%A3%D9%83%D8%AB%D8%B1-%D9%85%D9%86-13-%D9%85%D9%84%D9%8A%D9%88%D9%86-%D8%B4%D8%AE%D8%B5-%D8%AA%D9%84%D9%82%D9%88%D8%A7-%D8%A7%D9%84%D8%AC%D8%B1%D8%B9%D8%A9-%D8%A7%D9%84%D8%A3%D9%88%D9%84%D9%89-%D8%A7%D9%84%D9%84%D9%82%D8%A7%D8%AD-%D8%A7%D9%84%D9%85%D8%B6%D8%A7%D8%AF-%D9%84%D9%83%D9%88%D8%B1%D9%88%D9%86%D8%A7-%D9%81%D9%8A-%D8%A7%D9%84%D8%A3%D8%B1%D8%AF%D9%86,1750000,1300000,450000
+Jordan,2021-05-27,"Pfizer/BioNTech, Sinopharm/Beijing",https://www.facebook.com/ncscmjordan/photos/a.388629101483029/1452048765141052/,1879809,1389247,490562
+Jordan,2021-05-28,"Pfizer/BioNTech, Sinopharm/Beijing",https://www.facebook.com/ncscmjordan/posts/1453446755001253,1904235,1412419,491816
+Jordan,2021-06-06,"Pfizer/BioNTech, Sinopharm/Beijing",https://twitter.com/mohgovjo/status/1401540399093719048,2307978,1748084,559894
+Jordan,2021-06-08,"Pfizer/BioNTech, Sinopharm/Beijing, Sputnik V, Oxford/AstraZeneca",https://corona.moh.gov.jo/ar,2487617,1892782,594835

--- a/scripts/scripts/vaccinations/output/Jordan.csv
+++ b/scripts/scripts/vaccinations/output/Jordan.csv
@@ -4,19 +4,19 @@ Jordan,2021-01-23,"Pfizer/BioNTech, Sinopharm/Beijing",https://petra.gov.jo/Incl
 Jordan,2021-01-31,"Pfizer/BioNTech, Sinopharm/Beijing",https://twitter.com/PrimeMinistry/status/1355931355327197185,40000,40000,0
 Jordan,2021-02-22,"Pfizer/BioNTech, Sinopharm/Beijing",https://en.royanews.tv/news/25719/2021-02-22,80000,50000,30000
 Jordan,2021-02-25,"Pfizer/BioNTech, Sinopharm/Beijing",https://www.reuters.com/article/us-health-coronavirus-jordan/jordan-says-covid-19-vaccination-drive-to-accelerate-in-coming-weeks-idUSKBN2AP2VO,150000,,
-Jordan,2021-03-15,"Pfizer/BioNTech, Sinopharm/Beijing",http://www.jordantimes.com/news/local/155772-people-received-1st-dose-covid-vaccine-%E2%80%94-crisis-cell,204151,155772,48379
-Jordan,2021-03-17,"Pfizer/BioNTech, Sinopharm/Beijing",https://en.royanews.tv/news/26287/2021-03-17,241868,189456,52412
-Jordan,2021-03-21,"Pfizer/BioNTech, Sinopharm/Beijing",https://en.royanews.tv/news/26404/2021-03-21,272648,209278,63370
-Jordan,2021-03-24,"Pfizer/BioNTech, Sinopharm/Beijing",https://en.royanews.tv/news/26484/2021-03-24,320140,251197,68943
-Jordan,2021-03-30,"Pfizer/BioNTech, Sinopharm/Beijing",https://petra.gov.jo/Include/InnerPage.jsp?ID=33506&lang=en&name=en_news,409203,304946,104257
-Jordan,2021-04-07,"Pfizer/BioNTech, Sinopharm/Beijing",https://menafn.com/1101878861/Jordan-404912-people-receive-1st-dose-of-anti-COVID-19-vaccine-Crisis-cell?source=317,524533,404912,119621
-Jordan,2021-04-14,"Pfizer/BioNTech, Sinopharm/Beijing",https://petra.gov.jo/Include/InnerPage.jsp?ID=33858&lang=en&name=en_news,665226,543095,122131
-Jordan,2021-04-19,"Pfizer/BioNTech, Sinopharm/Beijing",https://petra.gov.jo/Include/InnerPage.jsp?ID=33968&lang=en&name=en_news,732052,607381,124671
-Jordan,2021-04-29,"Pfizer/BioNTech, Sinopharm/Beijing",https://petra.gov.jo/Include/InnerPage.jsp?ID=175868&lang=ar&name=news,919922,699328,220594
-Jordan,2021-05-04,"Pfizer/BioNTech, Sinopharm/Beijing",https://www.facebook.com/ncscmjordan/photos/a.388629101483029/1436628866683042,1091048,805020,286028
-Jordan,2021-05-18,"Pfizer/BioNTech, Sinopharm/Beijing",https://www.facebook.com/ncscmjordan/photos/a.388629101483029/1446122289067033/,1419950,1034808,385142
-Jordan,2021-05-26,"Pfizer/BioNTech, Sinopharm/Beijing",https://www.almamlakatv.com/news/63858-%D8%A3%D9%83%D8%AB%D8%B1-%D9%85%D9%86-13-%D9%85%D9%84%D9%8A%D9%88%D9%86-%D8%B4%D8%AE%D8%B5-%D8%AA%D9%84%D9%82%D9%88%D8%A7-%D8%A7%D9%84%D8%AC%D8%B1%D8%B9%D8%A9-%D8%A7%D9%84%D8%A3%D9%88%D9%84%D9%89-%D8%A7%D9%84%D9%84%D9%82%D8%A7%D8%AD-%D8%A7%D9%84%D9%85%D8%B6%D8%A7%D8%AF-%D9%84%D9%83%D9%88%D8%B1%D9%88%D9%86%D8%A7-%D9%81%D9%8A-%D8%A7%D9%84%D8%A3%D8%B1%D8%AF%D9%86,1750000,1300000,450000
-Jordan,2021-05-27,"Pfizer/BioNTech, Sinopharm/Beijing",https://www.facebook.com/ncscmjordan/photos/a.388629101483029/1452048765141052/,1879809,1389247,490562
-Jordan,2021-05-28,"Pfizer/BioNTech, Sinopharm/Beijing",https://www.facebook.com/ncscmjordan/posts/1453446755001253,1904235,1412419,491816
-Jordan,2021-06-06,"Pfizer/BioNTech, Sinopharm/Beijing",https://twitter.com/mohgovjo/status/1401540399093719048,2307978,1748084,559894
-Jordan,2021-06-08,"Pfizer/BioNTech, Sinopharm/Beijing, Sputnik V, Oxford/AstraZeneca",https://corona.moh.gov.jo/ar,2487617,1892782,594835
+Jordan,2021-03-15,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinopharm/Beijing,",http://www.jordantimes.com/news/local/155772-people-received-1st-dose-covid-vaccine-%E2%80%94-crisis-cell,204151,155772,48379
+Jordan,2021-03-17,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinopharm/Beijing",https://en.royanews.tv/news/26287/2021-03-17,241868,189456,52412
+Jordan,2021-03-21,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinopharm/Beijing",https://en.royanews.tv/news/26404/2021-03-21,272648,209278,63370
+Jordan,2021-03-24,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinopharm/Beijing",https://en.royanews.tv/news/26484/2021-03-24,320140,251197,68943
+Jordan,2021-03-30,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinopharm/Beijing",https://petra.gov.jo/Include/InnerPage.jsp?ID=33506&lang=en&name=en_news,409203,304946,104257
+Jordan,2021-04-07,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinopharm/Beijing",https://menafn.com/1101878861/Jordan-404912-people-receive-1st-dose-of-anti-COVID-19-vaccine-Crisis-cell?source=317,524533,404912,119621
+Jordan,2021-04-14,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinopharm/Beijing",https://petra.gov.jo/Include/InnerPage.jsp?ID=33858&lang=en&name=en_news,665226,543095,122131
+Jordan,2021-04-19,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinopharm/Beijing, Sputnik V",https://petra.gov.jo/Include/InnerPage.jsp?ID=33968&lang=en&name=en_news,732052,607381,124671
+Jordan,2021-04-29,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinopharm/Beijing, Sputnik V",https://petra.gov.jo/Include/InnerPage.jsp?ID=175868&lang=ar&name=news,919922,699328,220594
+Jordan,2021-05-04,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinopharm/Beijing, Sputnik V",https://www.facebook.com/ncscmjordan/photos/a.388629101483029/1436628866683042,1091048,805020,286028
+Jordan,2021-05-18,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinopharm/Beijing, Sputnik V",https://www.facebook.com/ncscmjordan/photos/a.388629101483029/1446122289067033/,1419950,1034808,385142
+Jordan,2021-05-26,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinopharm/Beijing, Sputnik V",https://www.almamlakatv.com/news/63858-%D8%A3%D9%83%D8%AB%D8%B1-%D9%85%D9%86-13-%D9%85%D9%84%D9%8A%D9%88%D9%86-%D8%B4%D8%AE%D8%B5-%D8%AA%D9%84%D9%82%D9%88%D8%A7-%D8%A7%D9%84%D8%AC%D8%B1%D8%B9%D8%A9-%D8%A7%D9%84%D8%A3%D9%88%D9%84%D9%89-%D8%A7%D9%84%D9%84%D9%82%D8%A7%D8%AD-%D8%A7%D9%84%D9%85%D8%B6%D8%A7%D8%AF-%D9%84%D9%83%D9%88%D8%B1%D9%88%D9%86%D8%A7-%D9%81%D9%8A-%D8%A7%D9%84%D8%A3%D8%B1%D8%AF%D9%86,1750000,1300000,450000
+Jordan,2021-05-27,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinopharm/Beijing, Sputnik V",https://www.facebook.com/ncscmjordan/photos/a.388629101483029/1452048765141052/,1879809,1389247,490562
+Jordan,2021-05-28,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinopharm/Beijing, Sputnik V",https://www.facebook.com/ncscmjordan/posts/1453446755001253,1904235,1412419,491816
+Jordan,2021-06-06,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinopharm/Beijing, Sputnik V",https://twitter.com/mohgovjo/status/1401540399093719048,2307978,1748084,559894
+Jordan,2021-06-08,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinopharm/Beijing, Sputnik V",https://corona.moh.gov.jo/ar,2487617,1892782,594835

--- a/scripts/scripts/vaccinations/src/vax/incremental/jordan.py
+++ b/scripts/scripts/vaccinations/src/vax/incremental/jordan.py
@@ -1,6 +1,5 @@
 import re
 
-import requests
 import pandas as pd
 from selenium import webdriver
 from selenium.webdriver.chrome.options import Options
@@ -12,83 +11,94 @@ from vax.utils.incremental import enrich_data, increment, clean_count
 from vax.utils.dates import localdate
 
 
-def read(source: str) -> pd.Series:
-    return connect_parse_data(source)
+class Jordan:
 
-def connect_parse_data(source: str) -> pd.Series:
-    op = Options()
-    op.add_argument("--headless")
+    def __init__(self):
+        self.location = "Jordan"
+        self.source_url = "https://corona.moh.gov.jo/ar"
 
-    with webdriver.Chrome(options=op) as driver:
-        # Main page
-        driver.get(source)
-        # Get report page from within iframe
-        source = driver.find_element_by_xpath("/html/body/section[2]/iframe").get_attribute("src")
+    def read(self) -> pd.Series:
+        return self._parse_data()
 
-        driver.get(source)
+    def _parse_data(self) -> pd.Series:
+        op = Options()
+        op.add_argument("--headless")
 
-        data_blocks = (
-            WebDriverWait(driver, 20)
-            .until(EC.visibility_of_all_elements_located((By.CLASS_NAME, "card")))
+        with webdriver.Chrome(options=op) as driver:
+            # Main page
+            driver.get(self.source_url)
+            # Get report page from within iframe
+            source = driver.find_element_by_xpath("/html/body/section[2]/iframe").get_attribute("src")
+
+            driver.get(source)
+
+            data_blocks = (
+                WebDriverWait(driver, 20)
+                .until(EC.visibility_of_all_elements_located((By.CLASS_NAME, "card")))
+            )
+            for block in data_blocks:
+                block_title = block.get_attribute("aria-label")
+                if "first dose" in block_title:
+                    people_vaccinated = re.search(r"first dose +(\d+)\.", block_title).group(1)
+                elif "sec dose" in block_title:
+                    people_fully_vaccinated = re.search(r"sec dose +(\d+)\.", block_title).group(1)
+
+            people_vaccinated=clean_count(people_vaccinated)
+            people_fully_vaccinated=clean_count(people_fully_vaccinated)
+
+        return pd.Series({
+            "people_vaccinated": people_vaccinated,
+            "people_fully_vaccinated": people_fully_vaccinated,
+        })
+
+    def pipe_vaccinations(self, ds: pd.Series) -> pd.Series:
+        total_vaccinations = ds.people_vaccinated + ds.people_fully_vaccinated
+        return enrich_data(ds, 'total_vaccinations', total_vaccinations)
+
+    def pipe_date(self, ds: pd.Series) -> pd.Series:
+        date = localdate("Asia/Amman")
+        return enrich_data(ds, 'date', date)
+
+    def pipe_location(self, ds: pd.Series) -> pd.Series:
+        return enrich_data(ds, 'location', self.location)
+
+    def pipe_vaccine(self, ds: pd.Series) -> pd.Series:
+        # Johnson&Johnson authorized, no doses arrived or given yet
+        vaccines_used = "Pfizer/BioNTech, Sinopharm/Beijing, Sputnik V, Oxford/AstraZeneca"
+        return enrich_data(ds, 'vaccine', vaccines_used) 
+
+    def pipe_source(self, ds: pd.Series) -> pd.Series:
+        return enrich_data(ds, 'source_url', self.source_url)
+
+    def pipeline(self, ds: pd.Series) -> pd.Series:
+        return (
+            ds
+            .pipe(self.pipe_vaccinations)
+            .pipe(self.pipe_date)
+            .pipe(self.pipe_location)
+            .pipe(self.pipe_vaccine)
+            .pipe(self.pipe_source)
         )
-        for block in data_blocks:
-            block_title = block.get_attribute("aria-label")
-            if "first dose" in block_title:
-                people_vaccinated = re.search(r"first dose +(\d+)\.", block_title).group(1)
-            elif "sec dose" in block_title:
-                people_fully_vaccinated = re.search(r"sec dose +(\d+)\.", block_title).group(1)
 
-        people_vaccinated=clean_count(people_fully_vaccinated)
-        people_fully_vaccinated=clean_count(people_fully_vaccinated)
-
-        total_vaccinations = people_vaccinated+people_fully_vaccinated
-
-    return pd.Series({
-        "total_vaccinations": total_vaccinations,
-        "people_vaccinated": people_vaccinated,
-        "people_fully_vaccinated": people_fully_vaccinated,
-    })
-
-def format_date(ds: pd.Series) -> pd.Series:
-    date = localdate("Asia/Amman")
-    return enrich_data(ds, 'date', date)
-
-def enrich_location(ds: pd.Series) -> pd.Series:
-    return enrich_data(ds, 'location', "Jordan")
-
-
-def enrich_vaccine(ds: pd.Series) -> pd.Series:
-    return enrich_data(ds, 'vaccine', "Pfizer/BioNTech, Sinopharm/Beijing, Sputnik V, Oxford/AstraZeneca") # Johnson&Johnson authorized, no doses arrived or given yet
-
-
-def enrich_source(ds: pd.Series) -> pd.Series:
-    return enrich_data(ds, 'source_url', "https://corona.moh.gov.jo/ar")
-
-
-def pipeline(ds: pd.Series) -> pd.Series:
-    return (
-        ds
-        .pipe(format_date)
-        .pipe(enrich_location)
-        .pipe(enrich_vaccine)
-        .pipe(enrich_source)
-    )
+    def to_csv(self, paths):
+        data = self.read().pipe(self.pipeline)
+        print(data)
+        increment(
+            paths=paths,
+            location=data['location'],
+            total_vaccinations=data['total_vaccinations'],
+            people_vaccinated=data['people_vaccinated'],
+            people_fully_vaccinated=data['people_fully_vaccinated'],
+            date=data['date'],
+            source_url=data['source_url'],
+            vaccine=data['vaccine']
+        )
 
 
 def main(paths):
     # At the date of this automation, only the Arabic version of the website had the vaccination numbers
-    source = "https://corona.moh.gov.jo/ar"
-    data = read(source).pipe(pipeline)
-    increment(
-        paths=paths,
-        location=data['location'],
-        total_vaccinations=data['total_vaccinations'],
-        people_vaccinated=data['people_vaccinated'],
-        people_fully_vaccinated=data['people_fully_vaccinated'],
-        date=data['date'],
-        source_url=data['source_url'],
-        vaccine=data['vaccine']
-    )
+    Jordan().to_csv(paths)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/scripts/vaccinations/src/vax/incremental/jordan.py
+++ b/scripts/scripts/vaccinations/src/vax/incremental/jordan.py
@@ -1,0 +1,94 @@
+import re
+
+import requests
+import pandas as pd
+from selenium import webdriver
+from selenium.webdriver.chrome.options import Options
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+
+from vax.utils.incremental import enrich_data, increment, clean_count
+from vax.utils.dates import localdate
+
+
+def read(source: str) -> pd.Series:
+    return connect_parse_data(source)
+
+def connect_parse_data(source: str) -> pd.Series:
+    op = Options()
+    op.add_argument("--headless")
+
+    with webdriver.Chrome(options=op) as driver:
+        # Main page
+        driver.get(source)
+        # Get report page from within iframe
+        source = driver.find_element_by_xpath("/html/body/section[2]/iframe").get_attribute("src")
+
+        driver.get(source)
+
+        data_blocks = (
+            WebDriverWait(driver, 20)
+            .until(EC.visibility_of_all_elements_located((By.CLASS_NAME, "card")))
+        )
+        for block in data_blocks:
+            block_title = block.get_attribute("aria-label")
+            if "first dose" in block_title:
+                people_vaccinated = re.search(r"first dose +(\d+)\.", block_title).group(1)
+            elif "sec dose" in block_title:
+                people_fully_vaccinated = re.search(r"sec dose +(\d+)\.", block_title).group(1)
+
+        people_vaccinated=clean_count(people_fully_vaccinated)
+        people_fully_vaccinated=clean_count(people_fully_vaccinated)
+
+        total_vaccinations = people_vaccinated+people_fully_vaccinated
+
+    return pd.Series({
+        "total_vaccinations": total_vaccinations,
+        "people_vaccinated": people_vaccinated,
+        "people_fully_vaccinated": people_fully_vaccinated,
+    })
+
+def format_date(ds: pd.Series) -> pd.Series:
+    date = localdate("Asia/Amman")
+    return enrich_data(ds, 'date', date)
+
+def enrich_location(ds: pd.Series) -> pd.Series:
+    return enrich_data(ds, 'location', "Jordan")
+
+
+def enrich_vaccine(ds: pd.Series) -> pd.Series:
+    return enrich_data(ds, 'vaccine', "Pfizer/BioNTech, Sinopharm/Beijing, Sputnik V, Oxford/AstraZeneca") # Johnson&Johnson authorized, no doses arrived or given yet
+
+
+def enrich_source(ds: pd.Series) -> pd.Series:
+    return enrich_data(ds, 'source_url', "https://corona.moh.gov.jo/ar")
+
+
+def pipeline(ds: pd.Series) -> pd.Series:
+    return (
+        ds
+        .pipe(format_date)
+        .pipe(enrich_location)
+        .pipe(enrich_vaccine)
+        .pipe(enrich_source)
+    )
+
+
+def main(paths):
+    # At the date of this automation, only the Arabic version of the website had the vaccination numbers
+    source = "https://corona.moh.gov.jo/ar"
+    data = read(source).pipe(pipeline)
+    increment(
+        paths=paths,
+        location=data['location'],
+        total_vaccinations=data['total_vaccinations'],
+        people_vaccinated=data['people_vaccinated'],
+        people_fully_vaccinated=data['people_fully_vaccinated'],
+        date=data['date'],
+        source_url=data['source_url'],
+        vaccine=data['vaccine']
+    )
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Hello

A few days ago, the Jordanian ministry of health added the vaccination numbers to the [online platform](https://corona.moh.gov.jo/ar) where it shares case and test numbers. I automated the retrieval of the numbers from the tracker. I tested it locally and it seems to work fine. Unfortunately, until today, the website only reports cumulative doses daily, so it is not in a batched format.

I've also fixed a couple typos in the README file.

Some notes regarding the vaccination drive in Jordan:
- The JFDA approved 6 vaccines so far: Sputnik V, Pfizer/Biontech, Oxford/Astrazeneca, J&J, and Sinopharm/Beijing. [Here](http://www.jordantimes.com/news/local/jfda-approves-russias-sputnik-covid-vaccine-emergency-use) and [here](https://en.royanews.tv/news/28618/2021-06-08) are relevant news sources. Moderna and J&J have been approved but no doses have been administered or have arrived to Jordan as of yet. I'm mentioning this to ask whether the vaccine type field should include these or not. 
- The website currently only reports 1st and 2nd doses, with no explicit number of fully vaccinated people. However, since J&J shipments have yet to come, I've used the number of 2nd doses as fully vaccinated. If the website changes, I'll make sure to let you know or do another PR.

Please let me know if there are any issues or if you would like me to refine anything.

Thank you!