### PR TITLE
Update Panama.csv

### DIFF
--- a/public/data/vaccinations/country_data/Panama.csv
+++ b/public/data/vaccinations/country_data/Panama.csv
@@ -103,3 +103,5 @@ Panama,2021-06-03,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINS
 Panama,2021-06-04,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1400958164065992707,1112847,722539,390308
 Panama,2021-06-06,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1401698487662690305,1134516,742448,392068
 Panama,2021-06-07,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1402063554593755168,1143067,748294,394773
+Panama,2021-06-08,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1402431045908287490,1145654,750805,394849
+Panama,2021-06-09,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1402776839018459139,1164396,757307,407089


### PR DESCRIPTION
Vaccination update against COVID-19 in the Republic of Panama corresponding to June 8 and 9 reported by the Ministry of Health.