### PR TITLE
Update Philippines.csv

### DIFF
--- a/public/data/vaccinations/locations.csv
+++ b/public/data/vaccinations/locations.csv
@@ -151,7 +151,7 @@ Panama,PAN,"Oxford/AstraZeneca, Pfizer/BioNTech",2021-06-09,Ministry of Health,h
 Papua New Guinea,PNG,"Oxford/AstraZeneca, Sinopharm/Beijing",2021-06-07,World Health Organization,https://covid19.who.int/
 Paraguay,PRY,"Covaxin, Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac, Sputnik V",2021-06-01,Government of Paraguay,https://twitter.com/msaludpy/status/1400075880999829505
 Peru,PER,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinopharm/Beijing",2021-06-08,Ministry of Health,https://www.datosabiertos.gob.pe/dataset/vacunaci%C3%B3n-contra-covid-19-ministerio-de-salud-minsa
-Philippines,PHL,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",2021-06-07,Government of the Philippines,https://www.facebook.com/102042448125024/posts/328741048788495/
+Philippines,PHL,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",2021-06-08,Government of the Philippines,https://news.abs-cbn.com/spotlight/multimedia/infographic/03/23/21/philippines-covid-19-vaccine-tracker
 Poland,POL,"Johnson&Johnson, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",2021-06-09,Ministry of Health,https://www.gov.pl/web/szczepimysie/raport-szczepien-przeciwko-covid-19
 Portugal,PRT,"Johnson&Johnson, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",2021-06-09,Directorate General for Health via Data Science for Social Good,https://github.com/dssg-pt/covid19pt-data
 Qatar,QAT,"Moderna, Pfizer/BioNTech",2021-06-09,Ministry of Public Health,https://covid19.moph.gov.qa/EN/Pages/Vaccination-Program-Data.aspx


### PR DESCRIPTION
As of June 8: 6,314,548 doses administered

Source: https://news.abs-cbn.com/spotlight/multimedia/infographic/03/23/21/philippines-covid-19-vaccine-tracker