### PR TITLE
Update Panama.csv

### DIFF
--- a/public/data/vaccinations/country_data/Panama.csv
+++ b/public/data/vaccinations/country_data/Panama.csv
@@ -97,11 +97,16 @@ Panama,2021-05-26,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINS
 Panama,2021-05-29,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1398782484180000768,1031694,662381,369313
 Panama,2021-05-30,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1399168168833212418,1056258,680689,375569
 Panama,2021-05-31,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1399508328699600901,1071998,694254,377734
-Panama,2021-06-01,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1399902802231635972,1080005,,
-Panama,2021-06-02,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1400230318855143432,1083856,697289,386567
-Panama,2021-06-03,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1400622902219874305,1100689,712383,388306
-Panama,2021-06-04,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1400958164065992707,1112847,722539,390308
-Panama,2021-06-06,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1401698487662690305,1134516,742448,392068
-Panama,2021-06-07,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1402063554593755168,1143067,748294,394773
-Panama,2021-06-08,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1402431053411799040,1145654,750805,394849
+Panama,2021-06-01,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1399902802231635972,1080005,700503,379502
+Panama,2021-06-02,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1400230318855143432,1083855,,384240
+Panama,2021-06-03,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1400622902219874305,1100689,714117,386572
+Panama,2021-06-04,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1400958164065992707,1112847,723356,389491
+Panama,2021-06-06,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1401698487662690305,1134516,744160,390356
+Panama,2021-06-07,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1402063554593755168,1143067,749786,393282
+Panama,2021-06-08,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1402431045908287490,1145654,750805,394849
 Panama,2021-06-09,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1402776839018459139,1164396,757307,407089
+Panama,2021-06-10,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1403145455329067012,1188731,769415,419316
+Panama,2021-06-11,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1403517143426215939,1220209,788633,429434
+Panama,2021-06-12,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1403889865842962432,1233583,796486,434955
+Panama,2021-06-13,"Pfizer/BioNTech, Oxford/AstraZeneca",http://minsa.gob.pa/noticia/comunicado-474,1281550,846566,434984
+


### PR DESCRIPTION
Vaccination update against COVID-19 in the Republic of Panama corresponding to June 10, 11, 12 and 13, 2021 reported by the Ministry of Health. 