### PR TITLE
Update Cambodia.csv

### DIFF
--- a/public/data/vaccinations/country_data/Cambodia.csv
+++ b/public/data/vaccinations/country_data/Cambodia.csv
@@ -117,3 +117,4 @@ Cambodia,2021-06-10,"Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac",http://www.
 Cambodia,2021-06-11,"Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac",http://www.freshnewsasia.com/index.php/en/localnews/201196-2021-06-11-14-22-23.html,5223954,2836482,2387472
 Cambodia,2021-06-12,"Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac",http://www.freshnewsasia.com/index.php/en/localnews/201290-2021-06-12-13-45-28.html,5325094,2885619,2439475
 Cambodia,2021-06-13,"Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac",http://www.freshnewsasia.com/index.php/en/localnews/201366-2021-06-13-13-24-33.html,5428433,2939543,2488890
+Cambodia,2021-06-14,"Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac",http://www.freshnewsasia.com/index.php/en/localnews/201532-2021-06-14-15-22-07.html,5537538,3000264,2537274


### PR DESCRIPTION
Cambodia vaccination update as of 14-Jun-21, 3 million people have received at least one dose and 5.5 million doses have been administered, making it the second fastest country in ASEAN and in Southeast Asia, according to the Prime Minister quoting information from Our World in Data.
<img width="800" alt="Screen Shot 2021-06-15 at 10 15 48 AM" src="https://user-images.githubusercontent.com/82133214/121988187-15535900-cdc4-11eb-968e-f6bab8d4fce9.png">

