### PR TITLE
Update Philippines.csv

### DIFF
--- a/public/data/vaccinations/locations.csv
+++ b/public/data/vaccinations/locations.csv
@@ -152,7 +152,7 @@ Panama,PAN,"Oxford/AstraZeneca, Pfizer/BioNTech",2021-06-18,Ministry of Health,h
 Papua New Guinea,PNG,"Oxford/AstraZeneca, Sinopharm/Beijing",2021-06-07,World Health Organization,https://covid19.who.int/
 Paraguay,PRY,"Covaxin, Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac, Sputnik V",2021-06-17,Government of Paraguay,https://www.vacunate.gov.py/index-listado-vacunados.html
 Peru,PER,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinopharm/Beijing",2021-06-17,Ministry of Health,https://www.datosabiertos.gob.pe/dataset/vacunaci%C3%B3n-contra-covid-19-ministerio-de-salud-minsa
-Philippines,PHL,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",2021-06-16,Government of the Philippines,https://news.abs-cbn.com/spotlight/multimedia/infographic/03/23/21/philippines-covid-19-vaccine-tracker
+Philippines,PHL,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",2021-06-18,Government of the Philippines,https://www.google.com/amp/s/www.gmanetwork.com/news/news/nation/792195/over-8-million-covid-19-vaccine-doses-administered-in-philippines-galvez/story/%3famp
 Pitcairn,PCN,Oxford/AstraZeneca,2021-06-15,SPC Public Health Division,https://stats.pacificdata.org/vis?tm=covid&pg=0&df[ds]=SPC2&df[id]=DF_COVID_VACCINATION&df[ag]=SPC&df[vs]=1.0
 Poland,POL,"Johnson&Johnson, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",2021-06-18,Ministry of Health,https://www.gov.pl/web/szczepimysie/raport-szczepien-przeciwko-covid-19
 Portugal,PRT,"Johnson&Johnson, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",2021-06-18,Directorate General for Health via Data Science for Social Good,https://github.com/dssg-pt/covid19pt-data


### PR DESCRIPTION
As of June 18: 8,050,711 doses administered

Source: https://www.google.com/amp/s/www.gmanetwork.com/news/news/nation/792195/over-8-million-covid-19-vaccine-doses-administered-in-philippines-galvez/story/%3famp