### PR TITLE
Update Panama.csv

### DIFF
--- a/public/data/vaccinations/country_data/Panama.csv
+++ b/public/data/vaccinations/country_data/Panama.csv
@@ -111,6 +111,7 @@ Panama,2021-06-12,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINS
 Panama,2021-06-13,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1404281079662526465,1281550,846566,434984
 Panama,2021-06-14,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1404579992038785026,1294993,858628,436365
 Panama,2021-06-15,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1404984589123211264,1327999,891151,436848
-Panama,2021-06-16,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1405346203030675463,1343784,,
-Panama,2021-06-17,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1405670570650390532,1370895,,
-Panama,2021-06-18,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1406075877713141761,1396100,,
+Panama,2021-06-16,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1405346203030675463,1343784,,452808
+Panama,2021-06-17,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1405670570650390532,1370895,903196,467699
+Panama,2021-06-18,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1406075877713141761,1396100,,478426
+Panama,2021-06-19,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1406448055692541952,1412477,929180,483297


### PR DESCRIPTION
Vaccination update against COVID-19 in the Republic of Panama corresponding to June 16, 17, 18 and 19, 2021 reported by the Ministry of Health of Panama.