### PR TITLE
Fix Colombia vaccinations data fetching

### DIFF
--- a/scripts/scripts/vaccinations/config.yaml
+++ b/scripts/scripts/vaccinations/config.yaml
@@ -7,7 +7,6 @@ pipeline:
     countries:
     njobs: -2
     skip_countries:
-      - Colombia
       - North Macedonia
       - Philippines
       - South Africa

--- a/scripts/scripts/vaccinations/output/Colombia.csv
+++ b/scripts/scripts/vaccinations/output/Colombia.csv
@@ -1,75 +1,106 @@
-date,total_vaccinations,people_fully_vaccinated,location,people_vaccinated,source_url,vaccine
-2021-02-17,18,,Colombia,,https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,"Pfizer/BioNTech, Sinovac"
-2021-02-18,9935,,Colombia,,https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,"Pfizer/BioNTech, Sinovac"
-2021-02-19,21307,,Colombia,,https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,"Pfizer/BioNTech, Sinovac"
-2021-02-20,33140,,Colombia,,https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,"Pfizer/BioNTech, Sinovac"
-2021-02-21,39827,,Colombia,,https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,"Pfizer/BioNTech, Sinovac"
-2021-02-22,45166,,Colombia,,https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,"Pfizer/BioNTech, Sinovac"
-2021-02-23,48150,,Colombia,,https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,"Pfizer/BioNTech, Sinovac"
-2021-02-24,50524,,Colombia,,https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,"Pfizer/BioNTech, Sinovac"
-2021-02-25,66157,,Colombia,,https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,"Pfizer/BioNTech, Sinovac"
-2021-02-26,81333,,Colombia,,https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,"Pfizer/BioNTech, Sinovac"
-2021-02-27,114042,,Colombia,,https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,"Pfizer/BioNTech, Sinovac"
-2021-02-28,130578,,Colombia,,https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,"Pfizer/BioNTech, Sinovac"
-2021-03-01,149133,,Colombia,,https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,"Pfizer/BioNTech, Sinovac"
-2021-03-02,169619,,Colombia,,https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,"Pfizer/BioNTech, Sinovac"
-2021-03-03,191480,,Colombia,,https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,"Pfizer/BioNTech, Sinovac"
-2021-03-04,206475,,Colombia,,https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,"Pfizer/BioNTech, Sinovac"
-2021-03-05,239851,,Colombia,,https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,"Pfizer/BioNTech, Sinovac"
-2021-03-06,270411,,Colombia,,https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,"Pfizer/BioNTech, Sinovac"
-2021-03-07,299400,,Colombia,,https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,"Pfizer/BioNTech, Sinovac"
-2021-03-08,316079,,Colombia,,https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,"Pfizer/BioNTech, Sinovac"
-2021-03-09,403095,,Colombia,,https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,"Pfizer/BioNTech, Sinovac"
-2021-03-10,480250,,Colombia,,https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,"Pfizer/BioNTech, Sinovac"
-2021-03-11,589208,,Colombia,,https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,"Pfizer/BioNTech, Sinovac"
-2021-03-12,693490,,Colombia,,https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,"Pfizer/BioNTech, Sinovac"
-2021-03-13,782301,33242,Colombia,749059,https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,"Pfizer/BioNTech, Sinovac"
-2021-03-14,843204,39548,Colombia,803656,https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,"Pfizer/BioNTech, Sinovac"
-2021-03-15,913961,44967,Colombia,868994,https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,"Pfizer/BioNTech, Sinovac"
-2021-03-16,976137,47210,Colombia,928927,https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,"Pfizer/BioNTech, Sinovac"
-2021-03-17,1024358,53118,Colombia,971240,https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,"Pfizer/BioNTech, Sinovac"
-2021-03-18,1076496,53892,Colombia,1022604,https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,"Pfizer/BioNTech, Sinovac"
-2021-03-19,1131999,54162,Colombia,1077837,https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,"Pfizer/BioNTech, Sinovac"
-2021-03-20,1182098,54528,Colombia,1127570,https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,"Pfizer/BioNTech, Sinovac"
-2021-03-21,1215008,57849,Colombia,1157159,https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,"Pfizer/BioNTech, Sinovac"
-2021-03-22,1238259,60324,Colombia,1177935,https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,"Pfizer/BioNTech, Sinovac"
-2021-03-23,1299809,62829,Colombia,1236980,https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,"Pfizer/BioNTech, Sinovac"
-2021-03-24,1385503,74274,Colombia,1311229,https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,"Pfizer/BioNTech, Sinovac"
-2021-03-25,1476364,117117,Colombia,1359247,https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,"Pfizer/BioNTech, Sinovac"
-2021-03-26,1596288,148108,Colombia,1448180,https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,"Pfizer/BioNTech, Sinovac"
-2021-03-27,1726924,176068,Colombia,1550856,https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,"Pfizer/BioNTech, Sinovac"
-2021-03-28,1818861,194296,Colombia,1624565,https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,"Pfizer/BioNTech, Sinovac"
-2021-03-29,1965054,228486,Colombia,1736568,https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac"
-2021-03-30,2121530,262707,Colombia,1858823,https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac"
-2021-03-31,2243392,286067,Colombia,1957325,https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac"
-2021-04-01,2300890,334955,Colombia,1965935,https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac"
-2021-04-02,2336144,364253,Colombia,1971891,https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac"
-2021-04-03,2381049,391193,Colombia,1989856,https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac"
-2021-04-04,2408085,402200,Colombia,2005885,https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac"
-2021-04-05,2479671,423536,Colombia,2056135,https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac"
-2021-04-07,2691513,542537,Colombia,2148976,https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac"
-2021-04-08,2812828,640077,Colombia,2172751,https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac"
-2021-04-09,2946222,744266,Colombia,2201956,https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac"
-2021-04-10,3041349,808785,Colombia,2232564,https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac"
-2021-04-12,3173583,914757,Colombia,2258826,https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac"
-2021-04-13,3350226,1009672,Colombia,2340554,https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac"
-2021-04-14,3455084,1047955,Colombia,2407129,https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac"
-2021-04-16,3590096,1093853,Colombia,2496243,https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac"
-2021-04-17,3707216,1135662,Colombia,2571554,https://app.powerbi.com/view?r=eyJrIjoiYjc0NTBhZGMtZGM2NS00YjA0LTljNGYtYTJkNWI1YTJlYzAwIiwidCI6Ijc0YzBjMjUwLTFjNzctNDA1ZC05YjFlLTlhYzFmNTA4YWJlMyIsImMiOjR9&pageName=ReportSectionad9662980220d3261e68,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac"
-2021-04-18,3769499,1155411,Colombia,2614088,https://app.powerbi.com/view?r=eyJrIjoiYjc0NTBhZGMtZGM2NS00YjA0LTljNGYtYTJkNWI1YTJlYzAwIiwidCI6Ijc0YzBjMjUwLTFjNzctNDA1ZC05YjFlLTlhYzFmNTA4YWJlMyIsImMiOjR9&pageName=ReportSectionad9662980220d3261e68,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac"
-2021-04-19,3867076,1188303,Colombia,2678773,https://app.powerbi.com/view?r=eyJrIjoiYjc0NTBhZGMtZGM2NS00YjA0LTljNGYtYTJkNWI1YTJlYzAwIiwidCI6Ijc0YzBjMjUwLTFjNzctNDA1ZC05YjFlLTlhYzFmNTA4YWJlMyIsImMiOjR9&pageName=ReportSectionad9662980220d3261e68,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac"
-2021-04-20,3979575,1231864,Colombia,2747711,https://app.powerbi.com/view?r=eyJrIjoiYjc0NTBhZGMtZGM2NS00YjA0LTljNGYtYTJkNWI1YTJlYzAwIiwidCI6Ijc0YzBjMjUwLTFjNzctNDA1ZC05YjFlLTlhYzFmNTA4YWJlMyIsImMiOjR9&pageName=ReportSectionad9662980220d3261e68,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac"
-2021-04-21,4131008,1280891,Colombia,2850117,https://app.powerbi.com/view?r=eyJrIjoiYjc0NTBhZGMtZGM2NS00YjA0LTljNGYtYTJkNWI1YTJlYzAwIiwidCI6Ijc0YzBjMjUwLTFjNzctNDA1ZC05YjFlLTlhYzFmNTA4YWJlMyIsImMiOjR9&pageName=ReportSectionad9662980220d3261e68,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac"
-2021-04-22,4224659,1320251,Colombia,2904408,https://app.powerbi.com/view?r=eyJrIjoiYjc0NTBhZGMtZGM2NS00YjA0LTljNGYtYTJkNWI1YTJlYzAwIiwidCI6Ijc0YzBjMjUwLTFjNzctNDA1ZC05YjFlLTlhYzFmNTA4YWJlMyIsImMiOjR9&pageName=ReportSectionad9662980220d3261e68,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac"
-2021-04-23,4318314,1357291,Colombia,2961023,https://app.powerbi.com/view?r=eyJrIjoiYjc0NTBhZGMtZGM2NS00YjA0LTljNGYtYTJkNWI1YTJlYzAwIiwidCI6Ijc0YzBjMjUwLTFjNzctNDA1ZC05YjFlLTlhYzFmNTA4YWJlMyIsImMiOjR9&pageName=ReportSectionad9662980220d3261e68,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac"
-2021-04-24,4400615,1391979,Colombia,3008636,https://app.powerbi.com/view?r=eyJrIjoiYjc0NTBhZGMtZGM2NS00YjA0LTljNGYtYTJkNWI1YTJlYzAwIiwidCI6Ijc0YzBjMjUwLTFjNzctNDA1ZC05YjFlLTlhYzFmNTA4YWJlMyIsImMiOjR9&pageName=ReportSectionad9662980220d3261e68,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac"
-2021-04-25,4451266,1411553,Colombia,3039713,https://app.powerbi.com/view?r=eyJrIjoiYjc0NTBhZGMtZGM2NS00YjA0LTljNGYtYTJkNWI1YTJlYzAwIiwidCI6Ijc0YzBjMjUwLTFjNzctNDA1ZC05YjFlLTlhYzFmNTA4YWJlMyIsImMiOjR9&pageName=ReportSectionad9662980220d3261e68,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac"
-2021-04-27,4625373,1476363,Colombia,3149010,https://app.powerbi.com/view?r=eyJrIjoiYjc0NTBhZGMtZGM2NS00YjA0LTljNGYtYTJkNWI1YTJlYzAwIiwidCI6Ijc0YzBjMjUwLTFjNzctNDA1ZC05YjFlLTlhYzFmNTA4YWJlMyIsImMiOjR9&pageName=ReportSectionad9662980220d3261e68,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac"
-2021-04-28,4714640,1505225,Colombia,3209415,https://app.powerbi.com/view?r=eyJrIjoiYjc0NTBhZGMtZGM2NS00YjA0LTljNGYtYTJkNWI1YTJlYzAwIiwidCI6Ijc0YzBjMjUwLTFjNzctNDA1ZC05YjFlLTlhYzFmNTA4YWJlMyIsImMiOjR9&pageName=ReportSectionad9662980220d3261e68,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac"
-2021-04-29,4824078,1546311,Colombia,3277767,https://app.powerbi.com/view?r=eyJrIjoiYjc0NTBhZGMtZGM2NS00YjA0LTljNGYtYTJkNWI1YTJlYzAwIiwidCI6Ijc0YzBjMjUwLTFjNzctNDA1ZC05YjFlLTlhYzFmNTA4YWJlMyIsImMiOjR9&pageName=ReportSectionad9662980220d3261e68,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac"
-2021-04-30,4986471,1627032,Colombia,3359439,https://app.powerbi.com/view?r=eyJrIjoiYjc0NTBhZGMtZGM2NS00YjA0LTljNGYtYTJkNWI1YTJlYzAwIiwidCI6Ijc0YzBjMjUwLTFjNzctNDA1ZC05YjFlLTlhYzFmNTA4YWJlMyIsImMiOjR9&pageName=ReportSectionad9662980220d3261e68,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac"
-2021-05-01,5112694,1700471,Colombia,3412223,https://app.powerbi.com/view?r=eyJrIjoiYjc0NTBhZGMtZGM2NS00YjA0LTljNGYtYTJkNWI1YTJlYzAwIiwidCI6Ijc0YzBjMjUwLTFjNzctNDA1ZC05YjFlLTlhYzFmNTA4YWJlMyIsImMiOjR9&pageName=ReportSectionad9662980220d3261e68,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac"
-2021-05-02,5220330,1766080,Colombia,3454250,https://app.powerbi.com/view?r=eyJrIjoiYjc0NTBhZGMtZGM2NS00YjA0LTljNGYtYTJkNWI1YTJlYzAwIiwidCI6Ijc0YzBjMjUwLTFjNzctNDA1ZC05YjFlLTlhYzFmNTA4YWJlMyIsImMiOjR9&pageName=ReportSectionad9662980220d3261e68,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac"
-2021-05-07,6096661,2235245,Colombia,3861416,https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac"
-2021-05-10,6478808,2440975,Colombia,4037833,https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac"
-2021-05-11,6673552,2533355,Colombia,4140197,https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac"
+location,date,vaccine,source_url,total_vaccinations,people_vaccinated,people_fully_vaccinated
+Colombia,2021-02-17,"Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,18,,
+Colombia,2021-02-18,"Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,9935,,
+Colombia,2021-02-19,"Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,21307,,
+Colombia,2021-02-20,"Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,33140,,
+Colombia,2021-02-21,"Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,39827,,
+Colombia,2021-02-22,"Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,45166,,
+Colombia,2021-02-23,"Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,48150,,
+Colombia,2021-02-24,"Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,50524,,
+Colombia,2021-02-25,"Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,66157,,
+Colombia,2021-02-26,"Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,81333,,
+Colombia,2021-02-27,"Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,114042,,
+Colombia,2021-02-28,"Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,130578,,
+Colombia,2021-03-01,"Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,149133,,
+Colombia,2021-03-02,"Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,169619,,
+Colombia,2021-03-03,"Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,191480,,
+Colombia,2021-03-04,"Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,206475,,
+Colombia,2021-03-05,"Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,239851,,
+Colombia,2021-03-06,"Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,270411,,
+Colombia,2021-03-07,"Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,299400,,
+Colombia,2021-03-08,"Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,316079,,
+Colombia,2021-03-09,"Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,403095,,
+Colombia,2021-03-10,"Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,480250,,
+Colombia,2021-03-11,"Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,589208,,
+Colombia,2021-03-12,"Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,693490,,
+Colombia,2021-03-13,"Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,782301,749059,33242
+Colombia,2021-03-14,"Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,843204,803656,39548
+Colombia,2021-03-15,"Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,913961,868994,44967
+Colombia,2021-03-16,"Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,976137,928927,47210
+Colombia,2021-03-17,"Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,1024358,971240,53118
+Colombia,2021-03-18,"Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,1076496,1022604,53892
+Colombia,2021-03-19,"Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,1131999,1077837,54162
+Colombia,2021-03-20,"Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,1182098,1127570,54528
+Colombia,2021-03-21,"Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,1215008,1157159,57849
+Colombia,2021-03-22,"Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,1238259,1177935,60324
+Colombia,2021-03-23,"Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,1299809,1236980,62829
+Colombia,2021-03-24,"Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,1385503,1311229,74274
+Colombia,2021-03-25,"Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,1476364,1359247,117117
+Colombia,2021-03-26,"Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,1596288,1448180,148108
+Colombia,2021-03-27,"Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,1726924,1550856,176068
+Colombia,2021-03-28,"Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,1818861,1624565,194296
+Colombia,2021-03-29,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,1965054,1736568,228486
+Colombia,2021-03-30,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,2121530,1858823,262707
+Colombia,2021-03-31,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,2243392,1957325,286067
+Colombia,2021-04-01,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,2300890,1965935,334955
+Colombia,2021-04-02,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,2336144,1971891,364253
+Colombia,2021-04-03,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,2381049,1989856,391193
+Colombia,2021-04-04,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,2408085,2005885,402200
+Colombia,2021-04-05,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,2479671,2056135,423536
+Colombia,2021-04-07,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,2691513,2148976,542537
+Colombia,2021-04-08,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,2812828,2172751,640077
+Colombia,2021-04-09,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,2946222,2201956,744266
+Colombia,2021-04-10,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,3041349,2232564,808785
+Colombia,2021-04-12,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,3173583,2258826,914757
+Colombia,2021-04-13,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,3350226,2340554,1009672
+Colombia,2021-04-14,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,3455084,2407129,1047955
+Colombia,2021-04-16,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,3590096,2496243,1093853
+Colombia,2021-04-17,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac",https://app.powerbi.com/view?r=eyJrIjoiYjc0NTBhZGMtZGM2NS00YjA0LTljNGYtYTJkNWI1YTJlYzAwIiwidCI6Ijc0YzBjMjUwLTFjNzctNDA1ZC05YjFlLTlhYzFmNTA4YWJlMyIsImMiOjR9&pageName=ReportSectionad9662980220d3261e68,3707216,2571554,1135662
+Colombia,2021-04-18,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac",https://app.powerbi.com/view?r=eyJrIjoiYjc0NTBhZGMtZGM2NS00YjA0LTljNGYtYTJkNWI1YTJlYzAwIiwidCI6Ijc0YzBjMjUwLTFjNzctNDA1ZC05YjFlLTlhYzFmNTA4YWJlMyIsImMiOjR9&pageName=ReportSectionad9662980220d3261e68,3769499,2614088,1155411
+Colombia,2021-04-19,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac",https://app.powerbi.com/view?r=eyJrIjoiYjc0NTBhZGMtZGM2NS00YjA0LTljNGYtYTJkNWI1YTJlYzAwIiwidCI6Ijc0YzBjMjUwLTFjNzctNDA1ZC05YjFlLTlhYzFmNTA4YWJlMyIsImMiOjR9&pageName=ReportSectionad9662980220d3261e68,3867076,2678773,1188303
+Colombia,2021-04-20,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac",https://app.powerbi.com/view?r=eyJrIjoiYjc0NTBhZGMtZGM2NS00YjA0LTljNGYtYTJkNWI1YTJlYzAwIiwidCI6Ijc0YzBjMjUwLTFjNzctNDA1ZC05YjFlLTlhYzFmNTA4YWJlMyIsImMiOjR9&pageName=ReportSectionad9662980220d3261e68,3979575,2747711,1231864
+Colombia,2021-04-21,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac",https://app.powerbi.com/view?r=eyJrIjoiYjc0NTBhZGMtZGM2NS00YjA0LTljNGYtYTJkNWI1YTJlYzAwIiwidCI6Ijc0YzBjMjUwLTFjNzctNDA1ZC05YjFlLTlhYzFmNTA4YWJlMyIsImMiOjR9&pageName=ReportSectionad9662980220d3261e68,4131008,2850117,1280891
+Colombia,2021-04-22,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac",https://app.powerbi.com/view?r=eyJrIjoiYjc0NTBhZGMtZGM2NS00YjA0LTljNGYtYTJkNWI1YTJlYzAwIiwidCI6Ijc0YzBjMjUwLTFjNzctNDA1ZC05YjFlLTlhYzFmNTA4YWJlMyIsImMiOjR9&pageName=ReportSectionad9662980220d3261e68,4224659,2904408,1320251
+Colombia,2021-04-23,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac",https://app.powerbi.com/view?r=eyJrIjoiYjc0NTBhZGMtZGM2NS00YjA0LTljNGYtYTJkNWI1YTJlYzAwIiwidCI6Ijc0YzBjMjUwLTFjNzctNDA1ZC05YjFlLTlhYzFmNTA4YWJlMyIsImMiOjR9&pageName=ReportSectionad9662980220d3261e68,4318314,2961023,1357291
+Colombia,2021-04-24,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac",https://app.powerbi.com/view?r=eyJrIjoiYjc0NTBhZGMtZGM2NS00YjA0LTljNGYtYTJkNWI1YTJlYzAwIiwidCI6Ijc0YzBjMjUwLTFjNzctNDA1ZC05YjFlLTlhYzFmNTA4YWJlMyIsImMiOjR9&pageName=ReportSectionad9662980220d3261e68,4400615,3008636,1391979
+Colombia,2021-04-25,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac",https://app.powerbi.com/view?r=eyJrIjoiYjc0NTBhZGMtZGM2NS00YjA0LTljNGYtYTJkNWI1YTJlYzAwIiwidCI6Ijc0YzBjMjUwLTFjNzctNDA1ZC05YjFlLTlhYzFmNTA4YWJlMyIsImMiOjR9&pageName=ReportSectionad9662980220d3261e68,4451266,3039713,1411553
+Colombia,2021-04-27,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac",https://app.powerbi.com/view?r=eyJrIjoiYjc0NTBhZGMtZGM2NS00YjA0LTljNGYtYTJkNWI1YTJlYzAwIiwidCI6Ijc0YzBjMjUwLTFjNzctNDA1ZC05YjFlLTlhYzFmNTA4YWJlMyIsImMiOjR9&pageName=ReportSectionad9662980220d3261e68,4625373,3149010,1476363
+Colombia,2021-04-28,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac",https://app.powerbi.com/view?r=eyJrIjoiYjc0NTBhZGMtZGM2NS00YjA0LTljNGYtYTJkNWI1YTJlYzAwIiwidCI6Ijc0YzBjMjUwLTFjNzctNDA1ZC05YjFlLTlhYzFmNTA4YWJlMyIsImMiOjR9&pageName=ReportSectionad9662980220d3261e68,4714640,3209415,1505225
+Colombia,2021-04-29,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac",https://app.powerbi.com/view?r=eyJrIjoiYjc0NTBhZGMtZGM2NS00YjA0LTljNGYtYTJkNWI1YTJlYzAwIiwidCI6Ijc0YzBjMjUwLTFjNzctNDA1ZC05YjFlLTlhYzFmNTA4YWJlMyIsImMiOjR9&pageName=ReportSectionad9662980220d3261e68,4824078,3277767,1546311
+Colombia,2021-04-30,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac",https://app.powerbi.com/view?r=eyJrIjoiYjc0NTBhZGMtZGM2NS00YjA0LTljNGYtYTJkNWI1YTJlYzAwIiwidCI6Ijc0YzBjMjUwLTFjNzctNDA1ZC05YjFlLTlhYzFmNTA4YWJlMyIsImMiOjR9&pageName=ReportSectionad9662980220d3261e68,4986471,3359439,1627032
+Colombia,2021-05-01,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac",https://app.powerbi.com/view?r=eyJrIjoiYjc0NTBhZGMtZGM2NS00YjA0LTljNGYtYTJkNWI1YTJlYzAwIiwidCI6Ijc0YzBjMjUwLTFjNzctNDA1ZC05YjFlLTlhYzFmNTA4YWJlMyIsImMiOjR9&pageName=ReportSectionad9662980220d3261e68,5112694,3412223,1700471
+Colombia,2021-05-02,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac",https://app.powerbi.com/view?r=eyJrIjoiYjc0NTBhZGMtZGM2NS00YjA0LTljNGYtYTJkNWI1YTJlYzAwIiwidCI6Ijc0YzBjMjUwLTFjNzctNDA1ZC05YjFlLTlhYzFmNTA4YWJlMyIsImMiOjR9&pageName=ReportSectionad9662980220d3261e68,5220330,3454250,1766080
+Colombia,2021-05-07,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/Paginas/Vacunacion-covid-19.aspx,6096661,3861416,2235245
+Colombia,2021-05-10,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/PublishingImages/Vacunas%20covid/100521_post_vacunas_covid.jpg,6478808,4037833,2440975
+Colombia,2021-05-11,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/PublishingImages/Vacunas%20covid/110521_post_vacunas_covid.jpg,6673552,4140197,2533355
+Colombia,2021-05-12,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/PublishingImages/Vacunas%20covid/120521_post_vacunas_covid.jpg,6851163,4238607,2612556
+Colombia,2021-05-13,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/PublishingImages/Vacunas%20covid/130521_post_vacunas_covid.jpg,7044644,4351490,2693154
+Colombia,2021-05-15,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/PublishingImages/Vacunas%20covid/160521_post_vacunas_covid.jpg.jpeg,7374433,4552042,2822391
+Colombia,2021-05-16,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/PublishingImages/Vacunas%20covid/170521_post_vacunas_covid.jpg.jpeg,7459332,4601785,2857547
+Colombia,2021-05-17,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/PublishingImages/Vacunas%20covid/170521_post_vacunas_covid.jpg,7537763,4652005,2885758
+Colombia,2021-05-18,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/PublishingImages/Vacunas%20covid/180521_post_vacunas_covid.jpg,7718287,4759397,2958890
+Colombia,2021-05-19,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/PublishingImages/Vacunas%20covid/190521_post_vacunas_covid.jpg,7862802,4861546,3001256
+Colombia,2021-05-20,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/PublishingImages/Vacunas%20covid/200521_post_vacunas_covid.jpg,8008919,4959877,3049042
+Colombia,2021-05-22,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/PublishingImages/Vacunas%20covid/230521_post_vacunas_covid.jpg.jpeg,8235482,5126062,3109420
+Colombia,2021-05-23,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/PublishingImages/Vacunas%20covid/230521_post_vacunas_covid.jpg,8304265,5176752,3127513
+Colombia,2021-05-24,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/PublishingImages/Vacunas%20covid/240521_post_vacunas_covid.jpg,8425588,5278110,3147478
+Colombia,2021-05-25,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/PublishingImages/Vacunas%20covid/250521_post_vacunas_covid.jpg,8613236,5439630,3173606
+Colombia,2021-05-26,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/PublishingImages/Vacunas%20covid/260521_post_vacunas_covid.jpg,8842360,5646512,3195848
+Colombia,2021-05-29,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/PublishingImages/Vacunas%20covid/WhatsApp%20Image%202021-05-30%20at%2011.46.34%20AM.jpeg,9661266,6399229,3262037
+Colombia,2021-05-30,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/PublishingImages/Vacunas%20covid/310521_post_vacunas_covid.jpg,9825772,6551917,3273855
+Colombia,2021-05-31,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/PublishingImages/Vacunas%20covid/310521_post_vacunas_covid.jpg,10092122,6798875,3293247
+Colombia,2021-06-01,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/PublishingImages/Vacunas%20covid/010621_post_vacunas_covid.jpg,10382967,7068568,3314399
+Colombia,2021-06-02,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/PublishingImages/Vacunas%20covid/020621_post_vacunas_covid.jpg,10697683,7359045,3338638
+Colombia,2021-06-03,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/PublishingImages/Vacunas%20covid/030621_post_vacunas_covid.jpg,10979983,7610719,3369264
+Colombia,2021-06-04,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/PublishingImages/Vacunas%20covid/050621_post_vacunas_covid.jpeg,11244592,7841655,3402937
+Colombia,2021-06-05,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/PublishingImages/Vacunas%20covid/050621_post_vacunas_covid.jpg,11485904,8053098,3432806
+Colombia,2021-06-06,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac",https://twitter.com/MinSaludCol/status/1401895588820619271,11615265,8164744,3450521
+Colombia,2021-06-07,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac",https://twitter.com/MinSaludCol/status/1402240088176738306,11733523,8262316,3471207
+Colombia,2021-06-08,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac",https://twitter.com/MinSaludCol/status/1402622562975223818,11977805,8442704,3535101
+Colombia,2021-06-09,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac",https://twitter.com/MinSaludCol/status/1402975610574606336,12206104,8612065,3594039
+Colombia,2021-06-11,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/PublishingImages/Vacunas%20covid/WhatsApp%20Image%202021-06-12%20at%209.08.22%20AM.jpeg,12711342,8975790,3735552
+Colombia,2021-06-12,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/PublishingImages/Vacunas%20covid/WhatsApp%20Image%202021-06-13%20at%208.11.13%20AM.jpeg,12917941,9117737,3800204
+Colombia,2021-06-13,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/PublishingImages/Vacunas%20covid/WhatsApp%20Image%202021-06-14%20at%207.56.08%20AM.jpeg,13024786,9194373,3830413
+Colombia,2021-06-14,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/PublishingImages/Vacunas%20covid/140621_post_vacunas_covid.jpg,13167044,9291221,3875823
+Colombia,2021-06-17,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/PublishingImages/Vacunas%20covid/170621_post_vacunas_covid.jpg,14062307,9736151,4326156
+Colombia,2021-06-19,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac",https://www.minsalud.gov.co/salud/publica/Vacunacion/PublishingImages/Vacunas%20covid/WhatsApp%20Image%202021-06-20%20at%208.34.37%20AM.jpeg,14727526,10071423,4656103

--- a/scripts/scripts/vaccinations/requirements.txt
+++ b/scripts/scripts/vaccinations/requirements.txt
@@ -2,7 +2,6 @@ beautifulsoup4==4.9.3
 chromedriver-binary==87.0.4280.88.0
 dateparser==1.0.0
 gsheets==0.5.1
-gspread==3.7.0
 joblib==1.0.1
 lxml>=4.6.3
 odfpy~=1.4.1

--- a/scripts/scripts/vaccinations/requirements.txt
+++ b/scripts/scripts/vaccinations/requirements.txt
@@ -2,6 +2,7 @@ beautifulsoup4==4.9.3
 chromedriver-binary==87.0.4280.88.0
 dateparser==1.0.0
 gsheets==0.5.1
+gspread==3.7.0
 joblib==1.0.1
 lxml>=4.6.3
 odfpy~=1.4.1

--- a/scripts/scripts/vaccinations/src/vax/cmd/__main__.py
+++ b/scripts/scripts/vaccinations/src/vax/cmd/__main__.py
@@ -24,12 +24,13 @@ def main():
             n_jobs=cfg.njobs,
             modules_name=cfg.countries,
             skip_countries=cfg.skip_countries,
+            gsheets_api=config.gsheets_api,
         )
     if "process" in config.mode:
         cfg = config.ProcessDataConfig()
         main_process_data(
             paths=paths,
-            google_credentials=creds.google_credentials,
+            gsheets_api=config.gsheets_api,
             google_spreadsheet_vax_id=creds.google_spreadsheet_vax_id,
             skip_complete=cfg.skip_complete,
             skip_monotonic=cfg.skip_monotonic_check,

--- a/scripts/scripts/vaccinations/src/vax/cmd/_config.py
+++ b/scripts/scripts/vaccinations/src/vax/cmd/_config.py
@@ -4,6 +4,7 @@ from datetime import date
 from pyaml_env import parse_config
 from itertools import chain
 
+from vax.utils.gsheets import GSheetApi
 from vax.cmd.get_data import (
     modules_name, modules_name_batch, modules_name_incremental, country_to_module
 )
@@ -69,6 +70,18 @@ class ConfigParams(object):
     @property
     def credentials_file_exists(self):
         return os.path.isfile(self.credentials_file)
+
+    @property
+    def google_credential_file(self):
+        field = "google_credentials"
+        if field in self._credentials:
+            return self._credentials[field]
+        else:
+            raise ValueError(f"Field 'google_credentials' not found in credentials file. Please check.")
+
+    @property
+    def gsheets_api(self):
+        return GSheetApi(self.google_credential_file)
 
     def _get_project_dir_from_config(self):
         try:

--- a/scripts/scripts/vaccinations/src/vax/cmd/process_data.py
+++ b/scripts/scripts/vaccinations/src/vax/cmd/process_data.py
@@ -1,6 +1,6 @@
 import pandas as pd
 
-from vax.utils.gsheets import GSheet
+from vax.utils.gsheets import VaccinationGSheet
 from vax.process import process_location
 from vax.cmd.utils import get_logger, print_eoe
 
@@ -8,13 +8,13 @@ from vax.cmd.utils import get_logger, print_eoe
 logger = get_logger()
 
 
-def main_process_data(paths, google_credentials: str, google_spreadsheet_vax_id: str, skip_complete: list = None,
+def main_process_data(paths, gsheets_api, google_spreadsheet_vax_id: str, skip_complete: list = None,
                       skip_monotonic: dict = {}, skip_anomaly: dict = {}):
     print("-- Processing data... --")
     # Get data from sheets
     logger.info("Getting data from Google Spreadsheet...")
-    gsheet = GSheet(
-        google_credentials,
+    gsheet = VaccinationGSheet(
+        gsheets_api,
         google_spreadsheet_vax_id
     )
     df_manual_list = gsheet.df_list()

--- a/scripts/scripts/vaccinations/src/vax/incremental/colombia.py
+++ b/scripts/scripts/vaccinations/src/vax/incremental/colombia.py
@@ -1,85 +1,92 @@
-import os
-
 import pandas as pd
-import json 
-
-import gspread
 
 from vax.utils.incremental import enrich_data, increment, clean_count
 from vax.utils.dates import clean_date
 
 
-def read(source: str) -> pd.Series:
-    return connect_parse_data(source)
+class Colombia:
 
-def open_google_sheet(source: str):
-    vax_credentials_file = os.environ['OWID_COVID_VAX_CREDENTIALS_FILE']
-    with open(vax_credentials_file) as f:
-        data = json.load(f)
-        google_credentials_json = data['google_credentials']
+    def __init__(self, gsheets_api) -> None:
+        self.location = "Colombia"
+        self.source_url = "https://docs.google.com/spreadsheets/d/1eblBeozGn1soDGXbOIicwyEDkUqNMzzpJoAKw84TTA4"
+        self.gsheets_api = gsheets_api
 
-    gc = gspread.service_account(google_credentials_json)
+    @property
+    def sheet_id(self):
+        return self.source_url.split("/")[-1]
 
-    ssh = gc.open_by_url(source)
-    wks = ssh.get_worksheet(1)
+    def read(self) -> pd.Series:
+        ws = self.gsheets_api.get_worksheet(self.sheet_id, "Reporte diario")
+        return self._parse_data(ws)
 
-    return wks
+    def _parse_data(self, worksheet):
+        if worksheet.nrows != 44:
+            raise ValueError("Sheet format changed!")
+        total_vaccinations = self._parse_total_vaccinations(worksheet)
+        people_fully_vaccinated = self._parse_people_fully_vaccinated(worksheet)
+        if total_vaccinations is None or people_fully_vaccinated is None:
+            return None
+        return pd.Series({
+            "date": self._parse_date(worksheet),
+            "total_vaccinations": total_vaccinations,
+            "people_fully_vaccinated": people_fully_vaccinated,
+        })
 
-def connect_parse_data(source: str) -> pd.Series:
-    sheet = open_google_sheet(source)
+    def _parse_total_vaccinations(self, worksheet):
+        nrow_doses_1 = 15
+        if worksheet.at(nrow_doses_1, 9) == "Total dosis aplicadas":
+            return worksheet.at(nrow_doses_1, 10)
 
-    date = sheet.get('C44').first().strip()
-    total_vaccinations = int(sheet.get('K16').first().strip().replace(',', ''))
-    people_fully_vaccinated = int(sheet.get('K27').first().strip().replace(',', ''))
+    def _parse_people_fully_vaccinated(self, worksheet):
+        nrow_doses_1 = 26
+        if worksheet.at(nrow_doses_1, 9) == "Total dosis acumuladas segundas dosis":
+            return worksheet.at(nrow_doses_1, 10)
 
-    people_vaccinated = total_vaccinations - people_fully_vaccinated
+    def _parse_date(self, worksheet):
+        nrow_date = 43
+        if worksheet.at(nrow_date, 1) == "Fecha de corte:":
+            return clean_date(worksheet.at(nrow_date, 2), "%d/%m/%Y")
+        else:
+            raise ValueError("Date is not where it is expected be! Check worksheet")
 
-    return pd.Series({
-        "total_vaccinations": total_vaccinations,
-        "people_vaccinated": people_vaccinated,
-        "people_fully_vaccinated": people_fully_vaccinated,
-        "date": clean_date(date, "%d/%m/%Y")
-    })
+    def pipe_metrics(self, ds: pd.Series) -> pd.Series:
+        return enrich_data(ds, "people_vaccinated", ds.total_vaccinations - ds.people_fully_vaccinated)
 
+    def pipe_location(self, ds: pd.Series) -> pd.Series:
+        return enrich_data(ds, "location", "Colombia")
 
-def enrich_location(ds: pd.Series) -> pd.Series:
-    return enrich_data(ds, "location", "Colombia")
+    def pipe_vaccine(self, ds: pd.Series) -> pd.Series:
+        return enrich_data(ds, "vaccine", "Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac")
 
+    def pipe_source(self, ds: pd.Series) -> pd.Series:
+        return enrich_data(ds, "source_url", self.source_url)
 
-def enrich_vaccine(ds: pd.Series) -> pd.Series:
-    return enrich_data(ds, "vaccine", "Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac")
+    def pipeline(self, ds: pd.Series) -> pd.Series:
+        return (
+            ds
+            .pipe(self.pipe_metrics)
+            .pipe(self.pipe_location)
+            .pipe(self.pipe_vaccine)
+            .pipe(self.pipe_source)
+        )
 
-
-def enrich_source(ds: pd.Series, source: str) -> pd.Series:
-    return enrich_data(ds, "source_url", source)
-
-
-def pipeline(ds: pd.Series, source: str) -> pd.Series:
-    return (
-        ds
-        .pipe(enrich_location)
-        .pipe(enrich_vaccine)
-        .pipe(enrich_source, source)
-    )
-
-
-def main(paths):
-    source = (
-        "https://docs.google.com/spreadsheets/d/1eblBeozGn1soDGXbOIicwyEDkUqNMzzpJoAKw84TTA4"
-    )
-    data = read(source).pipe(pipeline, source)
-
-    increment(
-        paths=paths,
-        location=data["location"],
-        total_vaccinations=data["total_vaccinations"],
-        people_vaccinated=data["people_vaccinated"],
-        people_fully_vaccinated=data["people_fully_vaccinated"],
-        date=data["date"],
-        source_url=data["source_url"],
-        vaccine=data["vaccine"]
-    )
+    def to_csv(self, paths):
+        data = self.read()
+        if "total_vaccinations" in data:
+            data = data.pipe(self.pipeline)
+            increment(
+                paths=paths,
+                location=data["location"],
+                total_vaccinations=data["total_vaccinations"],
+                people_vaccinated=data["people_vaccinated"],
+                people_fully_vaccinated=data["people_fully_vaccinated"],
+                date=data["date"],
+                source_url=data["source_url"],
+                vaccine=data["vaccine"]
+            )
+        else:
+            print("skipped")
 
 
-if __name__ == "__main__":
-    main()
+def main(paths, gsheets_api):
+    Colombia(gsheets_api=gsheets_api).to_csv(paths)

--- a/scripts/scripts/vaccinations/src/vax/incremental/colombia.py
+++ b/scripts/scripts/vaccinations/src/vax/incremental/colombia.py
@@ -1,5 +1,4 @@
-import re
-import time
+import os
 
 import pandas as pd
 import json 


### PR DESCRIPTION
This Pull Request uses the Google Sheets API to fetch the data from the
`https://docs.google.com/spreadsheets/d/1N4V-qqp6q8exuYAZgZ79GT9GazsSCHUK/edit#gid=625217412` file, created by _"Equipo Digital Presidencia"_, an official source from Colombia's president team.

However, since this is an Excel file, and therefore Sheets API doesn't work, data is replicated to [this file](https://docs.google.com/spreadsheets/d/1eblBeozGn1soDGXbOIicwyEDkUqNMzzpJoAKw84TTA4/edit#gid=625217412) through a Google Cloud cron job that does the update.

The data is updated daily at 9:00am COT (UTC-5).