### PR TITLE
Update Panama.csv

### DIFF
--- a/public/data/vaccinations/country_data/Panama.csv
+++ b/public/data/vaccinations/country_data/Panama.csv
@@ -119,3 +119,6 @@ Panama,2021-06-21,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINS
 Panama,2021-06-22,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1407505270117445636,1441646,,490211
 Panama,2021-06-23,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1407846614111293440,1444047,,499244
 Panama,2021-06-24,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1408217109243498500,1469057,961168,507889
+Panama,2021-06-25,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1408565107412586497,1485288,970196,515092
+Panama,2021-06-27,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1409287149573312517,1501657
+Panama,2021-06-28,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1409673206315712512,1518049,994064,523985


### PR DESCRIPTION
Vaccination update against COVID-19 in the Republic of Panama corresponding to June 25, 27 and 28, 2021 reported by the Ministry of Health of Panama.