### PR TITLE
Update Thailand.csv

### DIFF
--- a/public/data/vaccinations/country_data/Thailand.csv
+++ b/public/data/vaccinations/country_data/Thailand.csv
@@ -87,9 +87,12 @@ Thailand,2021-06-21,"Oxford/AstraZeneca, Sinovac",https://ddc.moph.go.th/uploads
 Thailand,2021-06-22,"Oxford/AstraZeneca, Sinovac",https://ddc.moph.go.th/uploads/ckeditor2//files/Daily%20report%202021-06-23.pdf,8148335,5844521,2303814
 Thailand,2021-06-23,"Oxford/AstraZeneca, Sinovac",https://ddc.moph.go.th/uploads/ckeditor2//files/Daily%20report%202021-06-24.pdf,8400320,6017424,2382896
 Thailand,2021-06-24,"Oxford/AstraZeneca, Sinovac",https://ddc.moph.go.th/uploads/ckeditor2//files/Daily%20Report%202021-06-25.pdf,8657423,6206353,2451070
-Thailand,2021-06-25,"Oxford/AstraZeneca, Sinovac",https://ddc.moph.go.th/uploads/ckeditor2//files/Daily%20report%202021-06-26.pdf,8981478,6435308,2546170
-Thailand,2021-06-26,"Oxford/AstraZeneca, Sinovac",https://ddc.moph.go.th/uploads/ckeditor2//files/Daily%20report%202021-06-27.pdf,9055141,6475826,2579315
-Thailand,2021-06-27,"Oxford/AstraZeneca, Sinovac",https://ddc.moph.go.th/uploads/ckeditor2//files/Daily%20report%202021-06-28.pdf,9147513,6537852,2609661
-Thailand,2021-06-28,"Oxford/AstraZeneca, Sinovac",https://ddc.moph.go.th/uploads/ckeditor2//files/Daily%20report%202021-06-29.pdf,9416972,6721038,2695394
-Thailand,2021-06-29,"Oxford/AstraZeneca, Sinovac",https://ddc.moph.go.th/uploads/ckeditor2//files/Daily%20report%202021-06-30.pdf,9672706,6910169,2762537
-Thailand,2021-07-01,"Oxford/AstraZeneca, Sinovac",https://ddc.moph.go.th/uploads/ckeditor2//files/Daily%20report%202021-07-02.pdf,10227183,7364585,2862598
+Thailand,2021-06-25,"Oxford/AstraZeneca, Sinovac, Sinopharm",https://ddc.moph.go.th/uploads/ckeditor2//files/Daily%20report%202021-06-26.pdf,8981478,6435308,2546170
+Thailand,2021-06-26,"Oxford/AstraZeneca, Sinovac, Sinopharm",https://ddc.moph.go.th/uploads/ckeditor2//files/Daily%20report%202021-06-27.pdf,9055141,6475826,2579315
+Thailand,2021-06-27,"Oxford/AstraZeneca, Sinovac, Sinopharm",https://ddc.moph.go.th/uploads/ckeditor2//files/Daily%20report%202021-06-28.pdf,9147513,6537852,2609661
+Thailand,2021-06-28,"Oxford/AstraZeneca, Sinovac, Sinopharm",https://ddc.moph.go.th/uploads/ckeditor2//files/Daily%20report%202021-06-29.pdf,9416972,6721038,2695394
+Thailand,2021-06-29,"Oxford/AstraZeneca, Sinovac, Sinopharm",https://ddc.moph.go.th/uploads/ckeditor2//files/Daily%20report%202021-06-30.pdf,9672706,6910169,2762537
+Thailand,2021-06-30,"Oxford/AstraZeneca, Sinovac, Sinopharm",https://ddc.moph.go.th/uploads/ckeditor2//files/Daily%20report%202021-07-01.pdf,9927698,7110854,2816844
+Thailand,2021-07-01,"Oxford/AstraZeneca, Sinovac, Sinopharm",https://ddc.moph.go.th/uploads/ckeditor2//files/Daily%20report%202021-07-02.pdf,10227183,7364585,2862598
+Thailand,2021-07-02,"Oxford/AstraZeneca, Sinovac, Sinopharm",https://ddc.moph.go.th/vaccine-covid19/getFiles/10/1625377983773.pdf,10572292,7640118,2932174
+Thailand,2021-07-03,"Oxford/AstraZeneca, Sinovac, Sinopharm",https://ddc.moph.go.th/vaccine-covid19/getFiles/10/1625378146400.pdf,10670897,7721150,2949747


### PR DESCRIPTION
I found that in a detailed report (can be found on the page https://ddc.moph.go.th/vaccine-covid19/diaryPresentMonth/06/10/2021) starting from 25th June, there is also Sinopharm vaccine. On the daily report, there is no information about it.