### PR TITLE
Update Panama.csv

### DIFF
--- a/public/data/vaccinations/country_data/Panama.csv
+++ b/public/data/vaccinations/country_data/Panama.csv
@@ -126,3 +126,4 @@ Panama,2021-06-29,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINS
 Panama,2021-06-30,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1410375110029189124,1553711,1018935,534776
 Panama,2021-07-01,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1410763397411508224,1572931,1026460,546471
 Panama,2021-07-04,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1411856133225123840,1600437,1038281,562156
+Panama,2021-07-05,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1412237642519961605,1614850,1045711,569139


### PR DESCRIPTION
Vaccination update against COVID-19 in the Republic of Panama corresponding to July 5, 2021.