### PR TITLE
Update Panama.csv

### DIFF
--- a/public/data/vaccinations/country_data/Panama.csv
+++ b/public/data/vaccinations/country_data/Panama.csv
@@ -124,8 +124,10 @@ Panama,2021-06-27,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINS
 Panama,2021-06-28,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1409673206315712512,1518049,994064,523985
 Panama,2021-06-29,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1410038067730259969,1534248,1007646,526602
 Panama,2021-06-30,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1410375110029189124,1553711,1018935,534776
-Panama,2021-07-01,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1410763397411508224,1572931,1026460,546471
+Panama,2021-07-01,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1410763397411508224,1572931,1026456,546475
 Panama,2021-07-04,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1411856133225123840,1600437,1038281,562156
 Panama,2021-07-05,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1412237642519961605,1614850,1045711,569139
-Panama,2021-07-06,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1412582466158743554,1646855,1067681,579174
-Panama,2021-07-07,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1412933928902664196,1664002,1075577,588425
+Panama,2021-07-06,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1412582466158743554,1646855,1073286,573569
+Panama,2021-07-07,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1412933928902664196,1664002,1082807,581195
+Panama,2021-07-08,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1413311945717977092,1688479,1096941,591538
+Panama,2021-07-09,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1413692845190430720,1724646,1121704,602942


### PR DESCRIPTION
Update and correction of the Vaccination against COVID-19 in the Republic of Panama corresponding to the month of July 2021.