### PR TITLE
Update Panama.csv

### DIFF
--- a/public/data/vaccinations/country_data/Panama.csv
+++ b/public/data/vaccinations/country_data/Panama.csv
@@ -131,5 +131,7 @@ Panama,2021-07-06,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINS
 Panama,2021-07-07,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1412933928902664196,1664002,1082807,581195
 Panama,2021-07-08,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1413311945717977092,1688479,1096941,591538
 Panama,2021-07-09,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1413692845190430720,1724646,1121704,602942
-Panama,2021-07-11,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1414380513914245124,1736269,,
-Panama,2021-07-12,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1414756099950092288,1749605,1125544,624061
+Panama,2021-07-11,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1414380513914245124,1736269,1127967,608302
+Panama,2021-07-12,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1414756099950092288,1749605,1133139,616466
+Panama,2021-07-13,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1415090465976770568,1763511,1139416,624095
+Panama,2021-07-14,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1415484837385932804,1781542,1149802,631740


### PR DESCRIPTION
Vaccination update against COVID-19 in the Republic of Panama corresponding to July 11, 12, 13 and 14, 2021 reported by the Ministry of Health 