### PR TITLE
Update on Vaccine used in Indonesia

### DIFF
--- a/public/data/vaccinations/country_data/Indonesia.csv
+++ b/public/data/vaccinations/country_data/Indonesia.csv
@@ -88,59 +88,59 @@ Indonesia,2021-05-13,"Oxford/AstraZeneca, Sinovac",https://vaksin.kemkes.go.id/#
 Indonesia,2021-05-14,"Oxford/AstraZeneca, Sinovac",https://vaksin.kemkes.go.id/#/vaccines,22622367,13700389,8921978
 Indonesia,2021-05-16,"Oxford/AstraZeneca, Sinovac",https://vaksin.kemkes.go.id/#/vaccines,22721097,13745160,8975937
 Indonesia,2021-05-17,"Oxford/AstraZeneca, Sinovac",https://vaksin.kemkes.go.id/#/vaccines,22922067,13828102,9093965
-Indonesia,2021-05-18,"Oxford/AstraZeneca, Sinovac",https://vaksin.kemkes.go.id/#/vaccines,23262139,13985952,9276187
-Indonesia,2021-05-20,"Oxford/AstraZeneca, Sinovac",https://vaksin.kemkes.go.id/#/vaccines,24033424,14452878,9580546
-Indonesia,2021-05-21,"Oxford/AstraZeneca, Sinovac",https://vaksin.kemkes.go.id/#/vaccines,24431758,14685236,9746522
-Indonesia,2021-05-23,"Oxford/AstraZeneca, Sinovac",https://vaksin.kemkes.go.id/#/vaccines,24790758,14909734,9881024
-Indonesia,2021-05-24,"Oxford/AstraZeneca, Sinovac",https://vaksin.kemkes.go.id/#/vaccines,24826221,14919592,9906629
-Indonesia,2021-05-25,"Oxford/AstraZeneca, Sinovac",https://vaksin.kemkes.go.id/#/vaccines,25782177,15546158,10236019
-Indonesia,2021-05-30,"Oxford/AstraZeneca, Sinovac",https://vaksin.kemkes.go.id/#/vaccines,26889189,16304700,10584489
-Indonesia,2021-05-31,"Oxford/AstraZeneca, Sinovac",https://vaksin.kemkes.go.id/#/vaccines,27045507,16413672,10631835
-Indonesia,2021-06-01,"Oxford/AstraZeneca, Sinovac",https://vaksin.kemkes.go.id/#/vaccines,27308881,16594581,10714300
-Indonesia,2021-06-02,"Oxford/AstraZeneca, Sinovac",https://vaksin.kemkes.go.id/#/vaccines,27619247,16766263,10852984
-Indonesia,2021-06-03,"Oxford/AstraZeneca, Sinovac",https://vaksin.kemkes.go.id/#/vaccines,28027750,17042850,10984900
-Indonesia,2021-06-04,"Oxford/AstraZeneca, Sinovac",https://vaksin.kemkes.go.id/#/vaccines,28486710,17416321,11070389
-Indonesia,2021-06-05,"Oxford/AstraZeneca, Sinovac",https://vaksin.kemkes.go.id/#/vaccines,28702933,17581464,11121469
-Indonesia,2021-06-06,"Oxford/AstraZeneca, Sinovac",https://vaksin.kemkes.go.id/#/vaccines,28770360,17643603,11126757
-Indonesia,2021-06-07,"Oxford/AstraZeneca, Sinovac",https://vaksin.kemkes.go.id/#/vaccines,28972987,17775918,11197069
-Indonesia,2021-06-08,"Oxford/AstraZeneca, Sinovac",https://vaksin.kemkes.go.id/#/vaccines,29616507,18260482,11356025
-Indonesia,2021-06-09,"Oxford/AstraZeneca, Sinovac",https://vaksin.kemkes.go.id/#/vaccines,30155028,18718769,11436259
-Indonesia,2021-06-10,"Oxford/AstraZeneca, Sinovac",https://vaksin.kemkes.go.id/#/vaccines,30700350,19211433,11488917
-Indonesia,2021-06-11,"Oxford/AstraZeneca, Sinovac",https://vaksin.kemkes.go.id/#/vaccines,31195606,19669968,11525638
-Indonesia,2021-06-12,"Oxford/AstraZeneca, Sinovac",https://vaksin.kemkes.go.id/#/vaccines,31603325,20044187,11559138
-Indonesia,2021-06-13,"Oxford/AstraZeneca, Sinovac",https://vaksin.kemkes.go.id/#/vaccines,31727380,20158937,11568443
-Indonesia,2021-06-14,"Oxford/AstraZeneca, Sinovac",https://vaksin.kemkes.go.id/#/vaccines,32039910,20424048,11615862
-Indonesia,2021-06-15,"Oxford/AstraZeneca, Sinovac",https://vaksin.kemkes.go.id/#/vaccines,32603744,20904723,11699021
-Indonesia,2021-06-16,"Oxford/AstraZeneca, Sinovac",https://vaksin.kemkes.go.id/#/vaccines,33264392,21448774,11815618
-Indonesia,2021-06-17,"Oxford/AstraZeneca, Sinovac",https://vaksin.kemkes.go.id/#/vaccines,33962386,21999256,11963130
-Indonesia,2021-06-18,"Oxford/AstraZeneca, Sinovac",https://vaksin.kemkes.go.id/#/vaccines,34551233,22455167,12096066
-Indonesia,2021-06-19,"Oxford/AstraZeneca, Sinovac",https://vaksin.kemkes.go.id/#/vaccines,35086248,22873342,12212906
-Indonesia,2021-06-20,"Oxford/AstraZeneca, Sinovac",https://vaksin.kemkes.go.id/#/vaccines,35283078,23043372,12239706
-Indonesia,2021-06-21,"Oxford/AstraZeneca, Sinovac",https://vaksin.kemkes.go.id/#/vaccines,35928647,23530219,12398428
-Indonesia,2021-06-22,"Oxford/AstraZeneca, Sinovac",https://vaksin.kemkes.go.id/#/vaccines,36581555,23998166,12583389
-Indonesia,2021-06-23,"Oxford/AstraZeneca, Sinovac",https://vaksin.kemkes.go.id/#/vaccines,36998897,24358856,12640041
-Indonesia,2021-06-24,"Oxford/AstraZeneca, Sinovac",https://vaksin.kemkes.go.id/#/vaccines,37699231,24929442,12769789
-Indonesia,2021-06-25,"Oxford/AstraZeneca, Sinovac",https://vaksin.kemkes.go.id/#/vaccines,38394659,25482036,12912623
-Indonesia,2021-06-26,"Oxford/AstraZeneca, Sinovac",https://vaksin.kemkes.go.id/#/vaccines,39050655,26032131,13018524
-Indonesia,2021-06-27,"Oxford/AstraZeneca, Sinovac",https://vaksin.kemkes.go.id/#/vaccines,40315983,27200222,13115761
-Indonesia,2021-06-28,"Oxford/AstraZeneca, Sinovac",https://vaksin.kemkes.go.id/#/vaccines,40601932,27419898,13182034
-Indonesia,2021-06-29,"Oxford/AstraZeneca, Sinovac",https://vaksin.kemkes.go.id/#/vaccines,42040501,28671106,13369395
-Indonesia,2021-06-30,"Oxford/AstraZeneca, Sinovac",https://vaksin.kemkes.go.id/#/vaccines,42744641,29279142,13465499
-Indonesia,2021-07-01,"Oxford/AstraZeneca, Sinovac",https://vaksin.kemkes.go.id/#/vaccines,44160960,30483730,13677230
-Indonesia,2021-07-02,"Oxford/AstraZeneca, Sinovac",https://vaksin.kemkes.go.id/#/vaccines,44661928,30891821,13770107
-Indonesia,2021-07-03,"Oxford/AstraZeneca, Sinovac",https://vaksin.kemkes.go.id/#/vaccines,45495972,31573240,13922732
-Indonesia,2021-07-04,"Oxford/AstraZeneca, Sinovac",https://vaksin.kemkes.go.id/#/vaccines,46043309,32063745,13979564
-Indonesia,2021-07-05,"Oxford/AstraZeneca, Sinovac",https://vaksin.kemkes.go.id/#/vaccines,46338202,32302268,14035934
-Indonesia,2021-07-06,"Oxford/AstraZeneca, Sinovac",https://vaksin.kemkes.go.id/#/vaccines,47444009,33176029,14267980
-Indonesia,2021-07-07,"Oxford/AstraZeneca, Sinovac",https://vaksin.kemkes.go.id/#/vaccines,48483610,34039797,14443813
-Indonesia,2021-07-08,"Oxford/AstraZeneca, Sinovac",https://vaksin.kemkes.go.id/#/vaccines,49483188,34860686,14622502
-Indonesia,2021-07-09,"Oxford/AstraZeneca, Sinovac",https://vaksin.kemkes.go.id/#/vaccines,50644144,35775567,14868577
-Indonesia,2021-07-10,"Oxford/AstraZeneca, Sinovac",https://vaksin.kemkes.go.id/#/vaccines,51162406,36193076,14969330
-Indonesia,2021-07-11,"Oxford/AstraZeneca, Sinovac",https://vaksin.kemkes.go.id/#/vaccines,51278367,36267019,15011348
-Indonesia,2021-07-12,"Oxford/AstraZeneca, Sinovac",https://vaksin.kemkes.go.id/#/vaccines,51404659,36368191,15036468
-Indonesia,2021-07-13,"Oxford/AstraZeneca, Sinovac",https://vaksin.kemkes.go.id/#/vaccines,51433567,36395019,15038548
-Indonesia,2021-07-14,"Oxford/AstraZeneca, Sinovac",https://vaksin.kemkes.go.id/#/vaccines,54520987,38909433,15611554
-Indonesia,2021-07-15,"Oxford/AstraZeneca, Sinovac",https://vaksin.kemkes.go.id/#/vaccines,55819781,39943004,15876777
-Indonesia,2021-07-16,"Oxford/AstraZeneca, Sinovac",https://vaksin.kemkes.go.id/#/vaccines,57011439,40912440,16098999
-Indonesia,2021-07-17,"Oxford/AstraZeneca, Sinovac",https://vaksin.kemkes.go.id/#/vaccines,57486482,41268627,16217855
-Indonesia,2021-07-18,"Oxford/AstraZeneca, Sinovac",https://vaksin.kemkes.go.id/#/vaccines,57947614,41673464,16274150
+Indonesia,2021-05-18,"Oxford/AstraZeneca, Sinovac, Sinopharm",https://vaksin.kemkes.go.id/#/vaccines,23262139,13985952,9276187
+Indonesia,2021-05-20,"Oxford/AstraZeneca, Sinovac, Sinopharm,https://vaksin.kemkes.go.id/#/vaccines,24033424,14452878,9580546
+Indonesia,2021-05-21,"Oxford/AstraZeneca, Sinovac, Sinopharm",https://vaksin.kemkes.go.id/#/vaccines,24431758,14685236,9746522
+Indonesia,2021-05-23,"Oxford/AstraZeneca, Sinovac, Sinopharm",https://vaksin.kemkes.go.id/#/vaccines,24790758,14909734,9881024
+Indonesia,2021-05-24,"Oxford/AstraZeneca, Sinovac, Sinopharm",https://vaksin.kemkes.go.id/#/vaccines,24826221,14919592,9906629
+Indonesia,2021-05-25,"Oxford/AstraZeneca, Sinovac, Sinopharm",https://vaksin.kemkes.go.id/#/vaccines,25782177,15546158,10236019
+Indonesia,2021-05-30,"Oxford/AstraZeneca, Sinovac, Sinopharm",https://vaksin.kemkes.go.id/#/vaccines,26889189,16304700,10584489
+Indonesia,2021-05-31,"Oxford/AstraZeneca, Sinovac, Sinopharm",https://vaksin.kemkes.go.id/#/vaccines,27045507,16413672,10631835
+Indonesia,2021-06-01,"Oxford/AstraZeneca, Sinovac, Sinopharm",https://vaksin.kemkes.go.id/#/vaccines,27308881,16594581,10714300
+Indonesia,2021-06-02,"Oxford/AstraZeneca, Sinovac, Sinopharm",https://vaksin.kemkes.go.id/#/vaccines,27619247,16766263,10852984
+Indonesia,2021-06-03,"Oxford/AstraZeneca, Sinovac, Sinopharm",https://vaksin.kemkes.go.id/#/vaccines,28027750,17042850,10984900
+Indonesia,2021-06-04,"Oxford/AstraZeneca, Sinovac, Sinopharm",https://vaksin.kemkes.go.id/#/vaccines,28486710,17416321,11070389
+Indonesia,2021-06-05,"Oxford/AstraZeneca, Sinovac, Sinopharm",https://vaksin.kemkes.go.id/#/vaccines,28702933,17581464,11121469
+Indonesia,2021-06-06,"Oxford/AstraZeneca, Sinovac, Sinopharm",https://vaksin.kemkes.go.id/#/vaccines,28770360,17643603,11126757
+Indonesia,2021-06-07,"Oxford/AstraZeneca, Sinovac, Sinopharm",https://vaksin.kemkes.go.id/#/vaccines,28972987,17775918,11197069
+Indonesia,2021-06-08,"Oxford/AstraZeneca, Sinovac, Sinopharm",https://vaksin.kemkes.go.id/#/vaccines,29616507,18260482,11356025
+Indonesia,2021-06-09,"Oxford/AstraZeneca, Sinovac, Sinopharm",https://vaksin.kemkes.go.id/#/vaccines,30155028,18718769,11436259
+Indonesia,2021-06-10,"Oxford/AstraZeneca, Sinovac, Sinopharm",https://vaksin.kemkes.go.id/#/vaccines,30700350,19211433,11488917
+Indonesia,2021-06-11,"Oxford/AstraZeneca, Sinovac, Sinopharm",https://vaksin.kemkes.go.id/#/vaccines,31195606,19669968,11525638
+Indonesia,2021-06-12,"Oxford/AstraZeneca, Sinovac, Sinopharm",https://vaksin.kemkes.go.id/#/vaccines,31603325,20044187,11559138
+Indonesia,2021-06-13,"Oxford/AstraZeneca, Sinovac, Sinopharm",https://vaksin.kemkes.go.id/#/vaccines,31727380,20158937,11568443
+Indonesia,2021-06-14,"Oxford/AstraZeneca, Sinovac, Sinopharm",https://vaksin.kemkes.go.id/#/vaccines,32039910,20424048,11615862
+Indonesia,2021-06-15,"Oxford/AstraZeneca, Sinovac, Sinopharm",https://vaksin.kemkes.go.id/#/vaccines,32603744,20904723,11699021
+Indonesia,2021-06-16,"Oxford/AstraZeneca, Sinovac, Sinopharm",https://vaksin.kemkes.go.id/#/vaccines,33264392,21448774,11815618
+Indonesia,2021-06-17,"Oxford/AstraZeneca, Sinovac, Sinopharm",https://vaksin.kemkes.go.id/#/vaccines,33962386,21999256,11963130
+Indonesia,2021-06-18,"Oxford/AstraZeneca, Sinovac, Sinopharm",https://vaksin.kemkes.go.id/#/vaccines,34551233,22455167,12096066
+Indonesia,2021-06-19,"Oxford/AstraZeneca, Sinovac, Sinopharm",https://vaksin.kemkes.go.id/#/vaccines,35086248,22873342,12212906
+Indonesia,2021-06-20,"Oxford/AstraZeneca, Sinovac, Sinopharm",https://vaksin.kemkes.go.id/#/vaccines,35283078,23043372,12239706
+Indonesia,2021-06-21,"Oxford/AstraZeneca, Sinovac, Sinopharm",https://vaksin.kemkes.go.id/#/vaccines,35928647,23530219,12398428
+Indonesia,2021-06-22,"Oxford/AstraZeneca, Sinovac, Sinopharm",https://vaksin.kemkes.go.id/#/vaccines,36581555,23998166,12583389
+Indonesia,2021-06-23,"Oxford/AstraZeneca, Sinovac, Sinopharm",https://vaksin.kemkes.go.id/#/vaccines,36998897,24358856,12640041
+Indonesia,2021-06-24,"Oxford/AstraZeneca, Sinovac, Sinopharm",https://vaksin.kemkes.go.id/#/vaccines,37699231,24929442,12769789
+Indonesia,2021-06-25,"Oxford/AstraZeneca, Sinovac, Sinopharm",https://vaksin.kemkes.go.id/#/vaccines,38394659,25482036,12912623
+Indonesia,2021-06-26,"Oxford/AstraZeneca, Sinovac, Sinopharm",https://vaksin.kemkes.go.id/#/vaccines,39050655,26032131,13018524
+Indonesia,2021-06-27,"Oxford/AstraZeneca, Sinovac, Sinopharm",https://vaksin.kemkes.go.id/#/vaccines,40315983,27200222,13115761
+Indonesia,2021-06-28,"Oxford/AstraZeneca, Sinovac, Sinopharm",https://vaksin.kemkes.go.id/#/vaccines,40601932,27419898,13182034
+Indonesia,2021-06-29,"Oxford/AstraZeneca, Sinovac, Sinopharm",https://vaksin.kemkes.go.id/#/vaccines,42040501,28671106,13369395
+Indonesia,2021-06-30,"Oxford/AstraZeneca, Sinovac, Sinopharm",https://vaksin.kemkes.go.id/#/vaccines,42744641,29279142,13465499
+Indonesia,2021-07-01,"Oxford/AstraZeneca, Sinovac, Sinopharm",https://vaksin.kemkes.go.id/#/vaccines,44160960,30483730,13677230
+Indonesia,2021-07-02,"Oxford/AstraZeneca, Sinovac, Sinopharm",https://vaksin.kemkes.go.id/#/vaccines,44661928,30891821,13770107
+Indonesia,2021-07-03,"Oxford/AstraZeneca, Sinovac, Sinopharm",https://vaksin.kemkes.go.id/#/vaccines,45495972,31573240,13922732
+Indonesia,2021-07-04,"Oxford/AstraZeneca, Sinovac, Sinopharm",https://vaksin.kemkes.go.id/#/vaccines,46043309,32063745,13979564
+Indonesia,2021-07-05,"Oxford/AstraZeneca, Sinovac, Sinopharm",https://vaksin.kemkes.go.id/#/vaccines,46338202,32302268,14035934
+Indonesia,2021-07-06,"Oxford/AstraZeneca, Sinovac, Sinopharm",https://vaksin.kemkes.go.id/#/vaccines,47444009,33176029,14267980
+Indonesia,2021-07-07,"Oxford/AstraZeneca, Sinovac, Sinopharm",https://vaksin.kemkes.go.id/#/vaccines,48483610,34039797,14443813
+Indonesia,2021-07-08,"Oxford/AstraZeneca, Sinovac, Sinopharm",https://vaksin.kemkes.go.id/#/vaccines,49483188,34860686,14622502
+Indonesia,2021-07-09,"Oxford/AstraZeneca, Sinovac, Sinopharm",https://vaksin.kemkes.go.id/#/vaccines,50644144,35775567,14868577
+Indonesia,2021-07-10,"Oxford/AstraZeneca, Sinovac, Sinopharm",https://vaksin.kemkes.go.id/#/vaccines,51162406,36193076,14969330
+Indonesia,2021-07-11,"Oxford/AstraZeneca, Sinovac, Sinopharm",https://vaksin.kemkes.go.id/#/vaccines,51278367,36267019,15011348
+Indonesia,2021-07-12,"Oxford/AstraZeneca, Sinovac, Sinopharm",https://vaksin.kemkes.go.id/#/vaccines,51404659,36368191,15036468
+Indonesia,2021-07-13,"Oxford/AstraZeneca, Sinovac, Sinopharm",https://vaksin.kemkes.go.id/#/vaccines,51433567,36395019,15038548
+Indonesia,2021-07-14,"Oxford/AstraZeneca, Sinovac, Sinopharm",https://vaksin.kemkes.go.id/#/vaccines,54520987,38909433,15611554
+Indonesia,2021-07-15,"Oxford/AstraZeneca, Sinovac, Sinopharm",https://vaksin.kemkes.go.id/#/vaccines,55819781,39943004,15876777
+Indonesia,2021-07-16,"Oxford/AstraZeneca, Sinovac, Sinopharm",https://vaksin.kemkes.go.id/#/vaccines,57011439,40912440,16098999
+Indonesia,2021-07-17,"Oxford/AstraZeneca, Sinovac, Sinopharm, Moderna",https://vaksin.kemkes.go.id/#/vaccines,57486482,41268627,16217855
+Indonesia,2021-07-18,"Oxford/AstraZeneca, Sinovac, Sinopharm, Moderna",https://vaksin.kemkes.go.id/#/vaccines,57947614,41673464,16274150

--- a/public/data/vaccinations/country_data/Indonesia.csv
+++ b/public/data/vaccinations/country_data/Indonesia.csv
@@ -88,7 +88,7 @@ Indonesia,2021-05-13,"Oxford/AstraZeneca, Sinovac",https://vaksin.kemkes.go.id/#
 Indonesia,2021-05-14,"Oxford/AstraZeneca, Sinovac",https://vaksin.kemkes.go.id/#/vaccines,22622367,13700389,8921978
 Indonesia,2021-05-16,"Oxford/AstraZeneca, Sinovac",https://vaksin.kemkes.go.id/#/vaccines,22721097,13745160,8975937
 Indonesia,2021-05-17,"Oxford/AstraZeneca, Sinovac",https://vaksin.kemkes.go.id/#/vaccines,22922067,13828102,9093965
-Indonesia,2021-05-18,"Oxford/AstraZeneca, Sinovac, Sinopharm",https://vaksin.kemkes.go.id/#/vaccines,23262139,13985952,9276187
+Indonesia,2021-05-18,"Oxford/AstraZeneca, Sinovac",https://vaksin.kemkes.go.id/#/vaccines,23262139,13985952,9276187
 Indonesia,2021-05-20,"Oxford/AstraZeneca, Sinovac, Sinopharm,https://vaksin.kemkes.go.id/#/vaccines,24033424,14452878,9580546
 Indonesia,2021-05-21,"Oxford/AstraZeneca, Sinovac, Sinopharm",https://vaksin.kemkes.go.id/#/vaccines,24431758,14685236,9746522
 Indonesia,2021-05-23,"Oxford/AstraZeneca, Sinovac, Sinopharm",https://vaksin.kemkes.go.id/#/vaccines,24790758,14909734,9881024


### PR DESCRIPTION
Sinopharm -> Start from 18 May 2021 (Article in Bahasa Indonesia: https://nasional.kontan.co.id/news/pihak-swasta-turut-terlibat-dalam-proses-distribusi-vaksinasi-gotong-royong)

Moderna -> Start from 17 July 2021 (Article in Bahasa Indonesia:https://news.detik.com/berita/d-5646185/vaksinasi-booster-moderna-untuk-nakes-dimulai-guru-besar-disuntik-pertama)

Indonesia have received 3 million (with 1.5 million more coming) Moderna shot from the United States. In Indonesia, the moderna shot is used as a 3rd booster shot for medical worker. In Indonesia, most if not all medical worker are vaccinated using Sinovac vaccine.

I think this is the only country in the world that combines two doses Sinovac and Moderna 3rd shot.