### PR TITLE
Update Panama.csv

### DIFF
--- a/public/data/vaccinations/country_data/Panama.csv
+++ b/public/data/vaccinations/country_data/Panama.csv
@@ -135,4 +135,7 @@ Panama,2021-07-11,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINS
 Panama,2021-07-12,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1414756099950092288,1749605,1133139,616466
 Panama,2021-07-13,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1415090465976770568,1763511,1139416,624095
 Panama,2021-07-14,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1415484837385932804,1781542,1149802,631740
-Panama,2021-07-15,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1415850797699579906,1810019,1162951,647068
+Panama,2021-07-15,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1415850797699579906,1810017,1169981,640038
+Panama,2021-07-16,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1416195498751447041,1841890,1193334,648556
+Panama,2021-07-18,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1416947558526722050,1876605,1227195,649410
+Panama,2021-07-19,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1417275252913156099,1877009,,656782


### PR DESCRIPTION
Vaccination update against COVID-19 in the Republic of Panama corresponding to July 14, 15, 16, 18 and 19 reported by the Ministry of Health