### PR TITLE
data(vax): Czechia: Moderna to be renamed to Spikevax

### DIFF
--- a/scripts/scripts/vaccinations/src/vax/batch/czechia.py
+++ b/scripts/scripts/vaccinations/src/vax/batch/czechia.py
@@ -10,7 +10,7 @@ from vax.utils.files import export_metadata
 
 vaccine_mapping = {
     "Comirnaty": "Pfizer/BioNTech",
-    "COVID-19 Vaccine Moderna": "Moderna",
+    "Spikevax": "Moderna",
     "VAXZEVRIA": "Oxford/AstraZeneca",
     "COVID-19 Vaccine Janssen": "Johnson&Johnson",
 }


### PR DESCRIPTION
The ministry has announced it will rename Moderna to Spikevax in its open data exports. This change should take place on Thursday (tomorrow), so I'm prepping this PR just to be safe - it should only be merged if the pipeline fails tomorrow.

Sources:
- https://translate.google.com/translate?sl=auto&tl=en&u=https://data.nzis.cz/news-detail/cs/38-zmena-nazvu-ockovaci-latky-moderna-na-spikevax/
- https://twitter.com/MartinKomenda1/status/1417533017954869249