### PR TITLE
Update Panama.csv

### DIFF
--- a/public/data/vaccinations/country_data/Panama.csv
+++ b/public/data/vaccinations/country_data/Panama.csv
@@ -138,5 +138,8 @@ Panama,2021-07-14,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINS
 Panama,2021-07-15,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1415850797699579906,1810017,1169979,640038
 Panama,2021-07-16,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1416195498751447041,1841890,1193334,648556
 Panama,2021-07-19,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1417275252913156099,1877009,1220227,656782
-Panama,2021-07-20,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1417668947722313731,1890415,1233492,656923
-Panama,2021-07-22,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1418400270539710464,1975276,1295751,679525
+Panama,2021-07-20,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1417668955867648002,1890415,1226715,663700
+Panama,2021-07-21,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1418035562129264646,1911404,1241588,669816
+Panama,2021-07-22,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1418400270539710464,1975276,1300265,675011
+Panama,2021-07-23,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1418708119245533187,2066597,1384491,682106
+Panama,2021-07-24,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1419134309554864137,2168541,1485279,683262


### PR DESCRIPTION
Vaccination update against COVID-19 in the Republic of Panama corresponding to days 20, 21, 22, 23 and 24 reported by the Ministry of Health.