### PR TITLE
Update Panama.csv

### DIFF
--- a/public/data/vaccinations/country_data/Panama.csv
+++ b/public/data/vaccinations/country_data/Panama.csv
@@ -143,3 +143,4 @@ Panama,2021-07-21,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINS
 Panama,2021-07-22,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1418400270539710464,1975276,1300265,675011
 Panama,2021-07-23,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1418708119245533187,2066597,1384491,682106
 Panama,2021-07-24,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1419134309554864137,2168541,1485279,683262
+Panama,2021-07-25,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1419493740465557504,2252051,1567945,684106


### PR DESCRIPTION
Vaccination update against COVID-19 in the Republic of Panama corresponding to July 26, 2021 reported by the Ministry of Health.