### PR TITLE
Fix Vaccine(s) used for Singapore

### DIFF
--- a/scripts/scripts/vaccinations/src/vax/incremental/singapore.py
+++ b/scripts/scripts/vaccinations/src/vax/incremental/singapore.py
@@ -55,7 +55,7 @@ class Singapore:
         return enrich_data(ds, "location", "Singapore")
 
     def pipe_vaccine(self, ds: pd.Series) -> pd.Series:
-        return enrich_data(ds, "vaccine", "Moderna, Pfizer/BioNTech, Sinovac")
+        return enrich_data(ds, "vaccine", "Moderna, Pfizer/BioNTech")
 
     def pipe_source(self, ds: pd.Series) -> pd.Series:
         return enrich_data(ds, "source_url", self.source_url)


### PR DESCRIPTION
While Sinovac is available, those vaccinated by it do not make up the vaccination tally. 

Source:
- Ministry of Health emailed statement was quoted https://www.nasdaq.com/articles/singapore-not-counting-sinovac-shots-in-covid-19-vaccination-tally-2021-07-07 
- https://youtu.be/nov_3jnLn2w?t=27