### PR TITLE
Update Panama.csv

### DIFF
--- a/public/data/vaccinations/country_data/Panama.csv
+++ b/public/data/vaccinations/country_data/Panama.csv
@@ -147,4 +147,8 @@ Panama,2021-07-25,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINS
 Panama,2021-07-28,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1420518329077403652,2327152,1637695,689457
 Panama,2021-07-29,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1420888782094622721,2408895,1717496,691399
 Panama,2021-07-30,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1421285755272454144,2573226,1878898,694328
-Panama,2021-08-02,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1422352037346414596,2803185,2103034,700151
+Panama,2021-07-31,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1421617684215648257,2679699,1984082,695617
+Panama,2021-08-01,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1422001839428472833,2753083,2056138,696945
+Panama,2021-08-02,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1422352037346414596,2803185,2103939,699246
+Panama,2021-08-03,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1422746622476304385,2818065,2117800,700225
+Panama,2021-08-04,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1423088817817460736,2844241,2133336,710905


### PR DESCRIPTION
Vaccination update against COVID-19 in the Republic of Panama corresponding to July 31, August 1, 2, 3 and 4, 2021.