### PR TITLE
Update Panama.csv

### DIFF
--- a/public/data/vaccinations/country_data/Panama.csv
+++ b/public/data/vaccinations/country_data/Panama.csv
@@ -152,3 +152,6 @@ Panama,2021-08-01,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINS
 Panama,2021-08-02,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1422352037346414596,2803185,2103939,699246
 Panama,2021-08-03,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1422746622476304385,2818065,2117800,700225
 Panama,2021-08-04,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1423088817817460736,2844241,2133336,710905
+Panama,2021-08-05,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1423456158493315072,2929481,2208721,720760
+Panama,2021-08-06,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1423853658580652037,3006726,2280937,725789
+Panama,2021-08-07,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1424188377969176576,3092971,2354177,738794


### PR DESCRIPTION
Vaccination update against COVID-19 in the Republic of Panama corresponding to August 5, 6, 7, 2021 reported by the Ministry of Health