### PR TITLE
Update Cambodia.csv

### DIFF
--- a/public/data/vaccinations/country_data/Cambodia.csv
+++ b/public/data/vaccinations/country_data/Cambodia.csv
@@ -172,3 +172,4 @@ Cambodia,2021-08-04,"Johnson&Johnson, Oxford/AstraZeneca, Sinopharm/Beijing, Sin
 Cambodia,2021-08-05,"Johnson&Johnson, Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac",https://www.facebook.com/MinistryofHealthofCambodia/photos/a.930887636950343/4266904736681933,13128308,7810469,5402478
 Cambodia,2021-08-06,"Johnson&Johnson, Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac",https://www.facebook.com/MinistryofHealthofCambodia/photos/a.930887636950343/4269902589715481,13393448,7927745,5597888
 Cambodia,2021-08-07,"Johnson&Johnson, Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac",https://www.facebook.com/MinistryofHealthofCambodia/photos/a.930887636950343/4272976689408071,13681376,8044707,5821021
+Cambodia,2021-08-08,"Johnson&Johnson, Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac",https://www.facebook.com/MinistryofHealthofCambodia/photos/a.930887636950343/4276007455771661,13949503,8151969,6019634


### PR DESCRIPTION
Cambodia has started giving AstraZeneca booster doses today (08 August 2021). The amount of total booster doses administered is included in total vaccinations, but I am not certain on how to report the booster doses itself in the script. I have not seen any new variable for us to report yet so I'm just gonna leave it blank for the time.