### PR TITLE
Update Cambodia.csv

### DIFF
--- a/public/data/vaccinations/country_data/Cambodia.csv
+++ b/public/data/vaccinations/country_data/Cambodia.csv
@@ -173,3 +173,4 @@ Cambodia,2021-08-05,"Johnson&Johnson, Oxford/AstraZeneca, Sinopharm/Beijing, Sin
 Cambodia,2021-08-06,"Johnson&Johnson, Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac",https://www.facebook.com/MinistryofHealthofCambodia/photos/a.930887636950343/4269902589715481,13393448,7927745,5597888
 Cambodia,2021-08-07,"Johnson&Johnson, Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac",https://www.facebook.com/MinistryofHealthofCambodia/photos/a.930887636950343/4272976689408071,13681376,8044707,5821021
 Cambodia,2021-08-08,"Johnson&Johnson, Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac",https://www.facebook.com/MinistryofHealthofCambodia/photos/a.930887636950343/4276007455771661,13949503,8151969,6019634
+Cambodia,2021-08-09,"Johnson&Johnson, Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac",https://www.facebook.com/MinistryofHealthofCambodia/photos/a.930887636950343/4278999122139161,14259583,8269744,6239954


### PR DESCRIPTION
**09-Aug-21:** Total vaccinations include total booster doses administered of 39,960 doses.