### PR TITLE
Update Panama.csv

### DIFF
--- a/public/data/vaccinations/country_data/Panama.csv
+++ b/public/data/vaccinations/country_data/Panama.csv
@@ -155,4 +155,8 @@ Panama,2021-08-04,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINS
 Panama,2021-08-05,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1423456158493315072,2929481,2208721,720760
 Panama,2021-08-06,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1423853658580652037,3006726,2280937,725789
 Panama,2021-08-07,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1424188377969176576,3092971,2354177,738794
-Panama,2021-08-10,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1425275454425083907,3187124,2412000,775124
+Panama,2021-08-08,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1424529389589606402,3142065,2398106,743959
+Panama,2021-08-09,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1424927444642017312,3184408,2437522,746886
+Panama,2021-08-10,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1425275454425083907,3182124,2425133,756991
+Panama,2021-08-11,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1425612079826939904,3217064,2429164,787900
+Panama,2021-08-12,"Pfizer/BioNTech, Oxford/AstraZeneca",https://twitter.com/MINSAPma/status/1426026305397604355,3292229,2469405,822824


### PR DESCRIPTION
Vaccination Update against COVID-19 in the Republic of Panama corresponding to August 7, 8, 9, 10, 11 and 12, 2021