### PR TITLE
Update Cambodia.csv

### DIFF
--- a/public/data/vaccinations/country_data/Cambodia.csv
+++ b/public/data/vaccinations/country_data/Cambodia.csv
@@ -176,3 +176,4 @@ Cambodia,2021-08-08,"Johnson&Johnson, Oxford/AstraZeneca, Sinopharm/Beijing, Sin
 Cambodia,2021-08-09,"Johnson&Johnson, Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac",https://www.facebook.com/MinistryofHealthofCambodia/photos/a.930887636950343/4278999122139161,14259583,8269744,6239954
 Cambodia,2021-08-10,"Johnson&Johnson, Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac",https://www.facebook.com/MinistryofHealthofCambodia/photos/a.930887636950343/4282020098503730,14554485,8396613,6438770
 Cambodia,2021-08-11,"Johnson&Johnson, Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac",https://www.facebook.com/MinistryofHealthofCambodia/photos/a.930887636950343/4285002341538839,14860238,8519714,6635999
+Cambodia,2021-08-12,"Johnson&Johnson, Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac",https://www.facebook.com/MinistryofHealthofCambodia/photos/a.930887636950343/4288235344548872,15136506,8639773,6815808


### PR DESCRIPTION
Total vaccinations include **total boosters** administered of 142,712 doses.