### PR TITLE
Update Tunisia

### DIFF
--- a/public/data/vaccinations/country_data/Tunisia.csv
+++ b/public/data/vaccinations/country_data/Tunisia.csv
@@ -1,120 +1,121 @@
-location,date,vaccine,source_url,total_vaccinations,people_vaccinated,people_fully_vaccinated,total_boosters
-Tunisia,2021-03-12,Sputnik V,https://www.africanews.com/2021/03/13/tunisia-begins-covid-vaccination-with-health-care-workers/,0,0,0,
-Tunisia,2021-03-13,Sputnik V,https://www.facebook.com/santetunisie.rns.tn/videos/488719478966036/,743,743,0,
-Tunisia,2021-03-14,Sputnik V,https://www.facebook.com/santetunisie.rns.tn/posts/3942942942411447,2076,2076,0,
-Tunisia,2021-03-15,Sputnik V,https://www.facebook.com/186480324724413/posts/3947631718609236/,2555,2555,0,
-Tunisia,2021-03-19,Sputnik V,https://www.facebook.com/186480324724413/posts/3958312024207872/,6861,6861,0,
-Tunisia,2021-03-21,"Pfizer/BioNTech, Sputnik V",https://www.facebook.com/186480324724413/posts/3963594130346328/,12496,12496,0,
-Tunisia,2021-03-22,"Pfizer/BioNTech, Sputnik V",https://www.facebook.com/186480324724413/posts/3967440006628407/,18020,18020,0,
-Tunisia,2021-03-23,"Pfizer/BioNTech, Sputnik V",https://www.facebook.com/186480324724413/posts/3971083486264059/,22040,22040,0,
-Tunisia,2021-03-25,"Pfizer/BioNTech, Sputnik V",https://www.facebook.com/186480324724413/posts/3977019415670466/,32026,32026,0,
-Tunisia,2021-03-26,"Pfizer/BioNTech, Sputnik V",https://www.facebook.com/186480324724413/posts/3980479405324467/,38853,38853,0,
-Tunisia,2021-03-27,"Pfizer/BioNTech, Sputnik V",https://www.facebook.com/186480324724413/posts/3983827844989623/,44311,44311,0,
-Tunisia,2021-03-29,"Pfizer/BioNTech, Sputnik V",https://www.facebook.com/186480324724413/posts/3991380950900979/,53089,53089,0,
-Tunisia,2021-04-02,"Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/186480324724413/posts/4005171509521923/,70769,70769,0,
-Tunisia,2021-04-03,"Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/186480324724413/posts/4008028735902867/,80140,80140,0,
-Tunisia,2021-04-04,"Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/186480324724413/posts/4011079642264443/,88543,88543,0,
-Tunisia,2021-04-05,"Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/186480324724413/posts/4013635495342191/,98057,98057,0,
-Tunisia,2021-04-06,"Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/186480324724413/posts/4014362261936181/,104922,104922,0,
-Tunisia,2021-04-07,"Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4019587711413636,112254,108266,3988,
-Tunisia,2021-04-08,"Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/186480324724413/posts/4023443124361428/,124779,119919,4860,
-Tunisia,2021-04-09,"Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4026210077418066,130374,125395,4979,
-Tunisia,2021-04-10,"Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4029183710454036,142932,134901,8031,
-Tunisia,2021-04-11,"Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4032491843456556,154647,146284,8363,
-Tunisia,2021-04-12,"Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4035131186525955,166093,157617,8476,
-Tunisia,2021-04-13,"Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4038685372837203,175439,166959,8480,
-Tunisia,2021-04-14,"Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4041065069265900,183025,174534,8491,
-Tunisia,2021-04-15,"Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4044200058952401,191625,180829,10796,
-Tunisia,2021-04-18,"Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4052878308084576,225900,192881,33019,
-Tunisia,2021-04-19,"Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4055960647776342,239398,197437,41961,
-Tunisia,2021-04-20,"Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4058963130809427,252672,204975,47697,
-Tunisia,2021-04-21,"Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4061581940547546,265365,214150,51215,
-Tunisia,2021-04-22,"Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4064492720256468,279890,225834,54056,
-Tunisia,2021-04-23,"Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4067981799907560,293073,235977,57096,
-Tunisia,2021-04-24,"Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4071091476263259,306612,244387,62225,
-Tunisia,2021-04-25,"Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4074049845967422,320009,254096,65913,
-Tunisia,2021-04-26,"Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4076982515674155,333000,263189,69811,
-Tunisia,2021-04-27,"Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4079877268718013,345914,271129,74785,
-Tunisia,2021-04-28,"Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4083118358393904,358746,277918,80828,
-Tunisia,2021-04-30,"Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4091947780844295,372083,282121,89962,
-Tunisia,2021-05-01,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4091947780844295,400364,305484,94880,
-Tunisia,2021-05-02,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4094595580579515,415801,314357,101444,
-Tunisia,2021-05-03,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4097476553624751,424485,320652,103833,
-Tunisia,2021-05-04,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4100444619994611,432878,325740,107138,
-Tunisia,2021-05-05,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4103935412978865,444490,330794,113696,
-Tunisia,2021-05-06,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4106526276053112,457568,333779,123789,
-Tunisia,2021-05-07,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4109753405730399,478755,340979,137776,
-Tunisia,2021-05-08,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4106526276053112,499369,350426,148943,
-Tunisia,2021-05-09,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4116076335098106,518538,362101,156437,
-Tunisia,2021-05-10,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4119228124782927,537380,372240,165140,
-Tunisia,2021-05-15,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4135206059851800,570553,392067,178486,
-Tunisia,2021-05-16,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4138076569564749,599969,414023,185946,
-Tunisia,2021-05-17,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4140999415939131,628107,432600,195507,
-Tunisia,2021-05-18,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.tap.info.tn/en/Portal-Society/14011339-covid-19-over-656,656077,450177,205900,
-Tunisia,2021-05-19,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4148182395220833,684173,466895,217278,
-Tunisia,2021-05-21,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4154427817929624,738667,494901,243766,
-Tunisia,2021-05-22,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4157386994300373,765751,512110,253641,
-Tunisia,2021-05-23,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4160871290618610,788578,528834,259744,
-Tunisia,2021-05-24,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4163575050348234,809163,542349,266814,
-Tunisia,2021-05-25,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4166822463356826,831824,560195,271629,
-Tunisia,2021-05-26,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4170204983018574,853432,578435,274997,
-Tunisia,2021-05-27,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4173183396054066,875808,597677,278131,
-Tunisia,2021-05-28,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4176282562410816,899109,616962,282147,
-Tunisia,2021-05-29,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4179617385410667,922838,633524,289314,
-Tunisia,2021-05-30,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4182377398467999,942532,644138,298394,
-Tunisia,2021-05-31,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4185228114849594,958951,654976,303975,
-Tunisia,2021-06-01,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4188267321212340,983647,672600,311047,
-Tunisia,2021-06-02,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4191107944261611,1016860,700087,316773,
-Tunisia,2021-06-03,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/186480324724413/posts/4194043443968061/,1051796,728092,322894,
-Tunisia,2021-06-04,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4197185420320530,1088158,758473,329685,
-Tunisia,2021-06-05,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4200178840021188,1126036,788222,337814,
-Tunisia,2021-06-06,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4203099836395755,1159924,814813,345111,
-Tunisia,2021-06-07,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4206030306102708,1192895,841051,351844,
-Tunisia,2021-06-08,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4208772962495109,1223563,871325,352238,
-Tunisia,2021-06-09,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4211589338880138,1252125,899555,352570,
-Tunisia,2021-06-10,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4214762748562797,1274840,921967,352873,
-Tunisia,2021-06-11,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4217303338308738,1312234,958531,353703,
-Tunisia,2021-06-12,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4220092064696532,1347889,986005,361884,
-Tunisia,2021-06-13,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4222662971106108,1381614,1012998,368616,
-Tunisia,2021-06-14,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4225538940818511,1405955,1032192,373763,
-Tunisia,2021-06-15,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4229279083777830,1433269,1055577,377692,
-Tunisia,2021-06-16,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4231303486908723,1459780,1079490,380290,
-Tunisia,2021-06-17,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4234629403242798,1486528,1104342,382186,
-Tunisia,2021-06-18,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4236757086363363,1517895,1126908,390987,
-Tunisia,2021-06-19,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4239635059408899,1551849,1147282,404567,
-Tunisia,2021-06-20,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4242069875832084,1583153,1165402,417751,
-Tunisia,2021-06-21,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4245597628812642,1609651,1181640,428011,
-Tunisia,2021-06-22,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4247870695252002,1636555,1198398,438157,
-Tunisia,2021-06-23,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4250577331648005,1661855,1215888,445967,
-Tunisia,2021-06-24,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4253646778007727,1685739,1223985,461754,
-Tunisia,2021-06-25,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4256628717709533,1705657,1229644,476013,
-Tunisia,2021-06-26,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4259519617420443,1737042,1240351,496691,
-Tunisia,2021-06-27,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4262260920479646,1765231,1251903,513328,
-Tunisia,2021-06-28,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4264906616881743,1793424,1260822,532602,
-Tunisia,2021-06-29,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4269265949779143,1821431,1272434,548997,
-Tunisia,2021-06-30,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4271458019559936,1844651,1290856,553795,
-Tunisia,2021-07-01,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4273726049333133,1881065,1314954,566111,
-Tunisia,2021-07-02,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4276669129038825,1912160,1342168,569992,
-Tunisia,2021-07-03,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4279396815432723,1942431,1367926,574505,
-Tunisia,2021-07-04,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4282202948485443,1972034,1390862,581172,
-Tunisia,2021-07-05,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4284785534893851,1999363,1407013,592350,
-Tunisia,2021-07-06,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4287775384594866,2024789,1424024,600765,
-Tunisia,2021-07-07,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4290649304307474,2052484,1444152,608332,
-Tunisia,2021-07-08,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4293872587318479,2082765,1468055,614710,
-Tunisia,2021-07-09,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4296286883743716,2115739,1497677,618062,
-Tunisia,2021-07-10,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4299246146781123,2138025,1514948,623077,
-Tunisia,2021-07-11,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4302127679826303,2156240,1525157,631083,
-Tunisia,2021-07-12,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4304958446209893,2178211,1527717,650494,
-Tunisia,2021-07-13,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4307717662600638,2206980,1530367,676613,
-Tunisia,2021-07-14,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4310674472304957,2234739,1532137,702602,
-Tunisia,2021-07-15,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4313426985363039,2269301,1541297,728004,
-Tunisia,2021-07-16,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4316357845069953,2304742,1549314,755428,
-Tunisia,2021-07-17,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4319563228082748,2347574,1566091,781483,
-Tunisia,2021-07-18,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4321967214509016,2385176,1583052,802124,
-Tunisia,2021-07-19,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4325086007530470,2420468,1595058,825410,
-Tunisia,2021-07-25,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4343196092386128,2619884,1681477,938407,
-Tunisia,2021-07-26,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4345730308799373,2663438,1699805,963633,
-Tunisia,2021-08-02,"Johnson&Johnson, Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://covid19.who.int/,2934709,1807279,,
-Tunisia,2021-08-04,"Johnson&Johnson, Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4373558156016588,3111252,1915124,,
-Tunisia,2021-08-07,"Johnson&Johnson, Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4381094728596264,3293114,2048054,1404936,
-Tunisia,2021-08-08,"Johnson&Johnson, Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://covid19.who.int/,3392636,2147121,,
+location,date,vaccine,source_url,total_vaccinations,people_vaccinated,people_fully_vaccinated
+Tunisia,2021-03-12,Sputnik V,https://www.africanews.com/2021/03/13/tunisia-begins-covid-vaccination-with-health-care-workers/,0,0,0
+Tunisia,2021-03-13,Sputnik V,https://www.facebook.com/santetunisie.rns.tn/videos/488719478966036/,743,743,0
+Tunisia,2021-03-14,Sputnik V,https://www.facebook.com/santetunisie.rns.tn/posts/3942942942411447,2076,2076,0
+Tunisia,2021-03-15,Sputnik V,https://www.facebook.com/186480324724413/posts/3947631718609236/,2555,2555,0
+Tunisia,2021-03-19,Sputnik V,https://www.facebook.com/186480324724413/posts/3958312024207872/,6861,6861,0
+Tunisia,2021-03-21,"Pfizer/BioNTech, Sputnik V",https://www.facebook.com/186480324724413/posts/3963594130346328/,12496,12496,0
+Tunisia,2021-03-22,"Pfizer/BioNTech, Sputnik V",https://www.facebook.com/186480324724413/posts/3967440006628407/,18020,18020,0
+Tunisia,2021-03-23,"Pfizer/BioNTech, Sputnik V",https://www.facebook.com/186480324724413/posts/3971083486264059/,22040,22040,0
+Tunisia,2021-03-25,"Pfizer/BioNTech, Sputnik V",https://www.facebook.com/186480324724413/posts/3977019415670466/,32026,32026,0
+Tunisia,2021-03-26,"Pfizer/BioNTech, Sputnik V",https://www.facebook.com/186480324724413/posts/3980479405324467/,38853,38853,0
+Tunisia,2021-03-27,"Pfizer/BioNTech, Sputnik V",https://www.facebook.com/186480324724413/posts/3983827844989623/,44311,44311,0
+Tunisia,2021-03-29,"Pfizer/BioNTech, Sputnik V",https://www.facebook.com/186480324724413/posts/3991380950900979/,53089,53089,0
+Tunisia,2021-04-02,"Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/186480324724413/posts/4005171509521923/,70769,70769,0
+Tunisia,2021-04-03,"Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/186480324724413/posts/4008028735902867/,80140,80140,0
+Tunisia,2021-04-04,"Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/186480324724413/posts/4011079642264443/,88543,88543,0
+Tunisia,2021-04-05,"Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/186480324724413/posts/4013635495342191/,98057,98057,0
+Tunisia,2021-04-06,"Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/186480324724413/posts/4014362261936181/,104922,104922,0
+Tunisia,2021-04-07,"Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4019587711413636,112254,108266,3988
+Tunisia,2021-04-08,"Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/186480324724413/posts/4023443124361428/,124779,119919,4860
+Tunisia,2021-04-09,"Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4026210077418066,130374,125395,4979
+Tunisia,2021-04-10,"Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4029183710454036,142932,134901,8031
+Tunisia,2021-04-11,"Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4032491843456556,154647,146284,8363
+Tunisia,2021-04-12,"Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4035131186525955,166093,157617,8476
+Tunisia,2021-04-13,"Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4038685372837203,175439,166959,8480
+Tunisia,2021-04-14,"Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4041065069265900,183025,174534,8491
+Tunisia,2021-04-15,"Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4044200058952401,191625,180829,10796
+Tunisia,2021-04-18,"Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4052878308084576,225900,192881,33019
+Tunisia,2021-04-19,"Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4055960647776342,239398,197437,41961
+Tunisia,2021-04-20,"Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4058963130809427,252672,204975,47697
+Tunisia,2021-04-21,"Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4061581940547546,265365,214150,51215
+Tunisia,2021-04-22,"Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4064492720256468,279890,225834,54056
+Tunisia,2021-04-23,"Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4067981799907560,293073,235977,57096
+Tunisia,2021-04-24,"Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4071091476263259,306612,244387,62225
+Tunisia,2021-04-25,"Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4074049845967422,320009,254096,65913
+Tunisia,2021-04-26,"Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4076982515674155,333000,263189,69811
+Tunisia,2021-04-27,"Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4079877268718013,345914,271129,74785
+Tunisia,2021-04-28,"Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4083118358393904,358746,277918,80828
+Tunisia,2021-04-30,"Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4091947780844295,372083,282121,89962
+Tunisia,2021-05-01,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4091947780844295,400364,305484,94880
+Tunisia,2021-05-02,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4094595580579515,415801,314357,101444
+Tunisia,2021-05-03,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4097476553624751,424485,320652,103833
+Tunisia,2021-05-04,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4100444619994611,432878,325740,107138
+Tunisia,2021-05-05,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4103935412978865,444490,330794,113696
+Tunisia,2021-05-06,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4106526276053112,457568,333779,123789
+Tunisia,2021-05-07,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4109753405730399,478755,340979,137776
+Tunisia,2021-05-08,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4106526276053112,499369,350426,148943
+Tunisia,2021-05-09,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4116076335098106,518538,362101,156437
+Tunisia,2021-05-10,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4119228124782927,537380,372240,165140
+Tunisia,2021-05-15,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4135206059851800,570553,392067,178486
+Tunisia,2021-05-16,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4138076569564749,599969,414023,185946
+Tunisia,2021-05-17,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4140999415939131,628107,432600,195507
+Tunisia,2021-05-18,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.tap.info.tn/en/Portal-Society/14011339-covid-19-over-656,656077,450177,205900
+Tunisia,2021-05-19,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4148182395220833,684173,466895,217278
+Tunisia,2021-05-21,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4154427817929624,738667,494901,243766
+Tunisia,2021-05-22,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4157386994300373,765751,512110,253641
+Tunisia,2021-05-23,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4160871290618610,788578,528834,259744
+Tunisia,2021-05-24,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4163575050348234,809163,542349,266814
+Tunisia,2021-05-25,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4166822463356826,831824,560195,271629
+Tunisia,2021-05-26,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4170204983018574,853432,578435,274997
+Tunisia,2021-05-27,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4173183396054066,875808,597677,278131
+Tunisia,2021-05-28,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4176282562410816,899109,616962,282147
+Tunisia,2021-05-29,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4179617385410667,922838,633524,289314
+Tunisia,2021-05-30,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4182377398467999,942532,644138,298394
+Tunisia,2021-05-31,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4185228114849594,958951,654976,303975
+Tunisia,2021-06-01,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4188267321212340,983647,672600,311047
+Tunisia,2021-06-02,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4191107944261611,1016860,700087,316773
+Tunisia,2021-06-03,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/186480324724413/posts/4194043443968061/,1051796,728092,322894
+Tunisia,2021-06-04,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4197185420320530,1088158,758473,329685
+Tunisia,2021-06-05,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4200178840021188,1126036,788222,337814
+Tunisia,2021-06-06,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4203099836395755,1159924,814813,345111
+Tunisia,2021-06-07,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4206030306102708,1192895,841051,351844
+Tunisia,2021-06-08,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4208772962495109,1223563,871325,352238
+Tunisia,2021-06-09,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4211589338880138,1252125,899555,352570
+Tunisia,2021-06-10,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4214762748562797,1274840,921967,352873
+Tunisia,2021-06-11,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4217303338308738,1312234,958531,353703
+Tunisia,2021-06-12,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4220092064696532,1347889,986005,361884
+Tunisia,2021-06-13,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4222662971106108,1381614,1012998,368616
+Tunisia,2021-06-14,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4225538940818511,1405955,1032192,373763
+Tunisia,2021-06-15,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4229279083777830,1433269,1055577,377692
+Tunisia,2021-06-16,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4231303486908723,1459780,1079490,380290
+Tunisia,2021-06-17,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4234629403242798,1486528,1104342,382186
+Tunisia,2021-06-18,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4236757086363363,1517895,1126908,390987
+Tunisia,2021-06-19,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4239635059408899,1551849,1147282,404567
+Tunisia,2021-06-20,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4242069875832084,1583153,1165402,417751
+Tunisia,2021-06-21,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4245597628812642,1609651,1181640,428011
+Tunisia,2021-06-22,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4247870695252002,1636555,1198398,438157
+Tunisia,2021-06-23,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4250577331648005,1661855,1215888,445967
+Tunisia,2021-06-24,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4253646778007727,1685739,1223985,461754
+Tunisia,2021-06-25,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4256628717709533,1705657,1229644,476013
+Tunisia,2021-06-26,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4259519617420443,1737042,1240351,496691
+Tunisia,2021-06-27,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4262260920479646,1765231,1251903,513328
+Tunisia,2021-06-28,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4264906616881743,1793424,1260822,532602
+Tunisia,2021-06-29,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4269265949779143,1821431,1272434,548997
+Tunisia,2021-06-30,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4271458019559936,1844651,1290856,553795
+Tunisia,2021-07-01,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4273726049333133,1881065,1314954,566111
+Tunisia,2021-07-02,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4276669129038825,1912160,1342168,569992
+Tunisia,2021-07-03,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4279396815432723,1942431,1367926,574505
+Tunisia,2021-07-04,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4282202948485443,1972034,1390862,581172
+Tunisia,2021-07-05,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4284785534893851,1999363,1407013,592350
+Tunisia,2021-07-06,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4287775384594866,2024789,1424024,600765
+Tunisia,2021-07-07,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4290649304307474,2052484,1444152,608332
+Tunisia,2021-07-08,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4293872587318479,2082765,1468055,614710
+Tunisia,2021-07-09,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4296286883743716,2115739,1497677,618062
+Tunisia,2021-07-10,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4299246146781123,2138025,1514948,623077
+Tunisia,2021-07-11,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4302127679826303,2156240,1525157,631083
+Tunisia,2021-07-12,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4304958446209893,2178211,1527717,650494
+Tunisia,2021-07-13,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4307717662600638,2206980,1530367,676613
+Tunisia,2021-07-14,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4310674472304957,2234739,1532137,702602
+Tunisia,2021-07-15,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4313426985363039,2269301,1541297,728004
+Tunisia,2021-07-16,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4316357845069953,2304742,1549314,755428
+Tunisia,2021-07-17,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4319563228082748,2347574,1566091,781483
+Tunisia,2021-07-18,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4321967214509016,2385176,1583052,802124
+Tunisia,2021-07-19,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4325086007530470,2420468,1595058,825410
+Tunisia,2021-07-25,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4343196092386128,2619884,1681477,938407
+Tunisia,2021-07-26,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4345730308799373,2663438,1699805,963633
+Tunisia,2021-08-02,"Johnson&Johnson, Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://covid19.who.int/,2934709,1807279,
+Tunisia,2021-08-04,"Johnson&Johnson, Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4373558156016588,3111252,1915124,
+Tunisia,2021-08-07,"Johnson&Johnson, Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://www.facebook.com/santetunisie.rns.tn/posts/4381094728596264,3293114,2048054,1404936
+Tunisia,2021-08-08,"Johnson&Johnson, Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://covid19.who.int/,3392636,2147121,
+Tunisia,2021-08-12,"Johnson&Johnson, Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac, Sputnik V",https://evax.tn/vaccinationOD.html


### PR DESCRIPTION
Total doses administrated: 3 970 115
First dose: 2 703 133
Fully vaccinated: 1 689 253
The the link for the data:
https://evax.tn/vaccinationOD.html
Also Tunisia start using sinopharm vaccine