### PR TITLE
Update Cambodia & fix J&J duplication.csv

### DIFF
--- a/public/data/vaccinations/country_data/Cambodia.csv
+++ b/public/data/vaccinations/country_data/Cambodia.csv
@@ -176,4 +176,5 @@ Cambodia,2021-08-08,"Johnson&Johnson, Oxford/AstraZeneca, Sinopharm/Beijing, Sin
 Cambodia,2021-08-09,"Johnson&Johnson, Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac",https://www.facebook.com/MinistryofHealthofCambodia/photos/a.930887636950343/4278999122139161,14259583,8269744,6239954,39960
 Cambodia,2021-08-10,"Johnson&Johnson, Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac",https://www.facebook.com/MinistryofHealthofCambodia/photos/a.930887636950343/4282020098503730,14554485,8396613,6438770,67637
 Cambodia,2021-08-11,"Johnson&Johnson, Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac",https://www.facebook.com/MinistryofHealthofCambodia/photos/a.930887636950343/4285002341538839,14860238,8519714,6635999,109509
-Cambodia,2021-08-12,"Johnson&Johnson, Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac",https://www.facebook.com/MinistryofHealthofCambodia/photos/a.930887636950343/4288235344548872/,15598293,8639773,6815808,142712
+Cambodia,2021-08-12,"Johnson&Johnson, Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac",https://www.facebook.com/MinistryofHealthofCambodia/photos/a.930887636950343/4288235344548872/,15136506,8639773,6815808,142712
+Cambodia,2021-08-13,"Johnson&Johnson, Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac",https://www.facebook.com/MinistryofHealthofCambodia/photos/a.930887636950343/4291148850924188/,15372439,8749906,6967688,167216


### PR DESCRIPTION
In the Cambodian Ministry of Health's announcement, both 1st doses (people vaccinated) and 2nd doses (completed dose) administered include J&J vaccine. So, total vaccinations must deduct J&J. Likewise, I found an error in 12 Aug 2021. This should be good now.