### PR TITLE
Update Serbia.csv

### DIFF
--- a/public/data/vaccinations/country_data/Serbia.csv
+++ b/public/data/vaccinations/country_data/Serbia.csv
@@ -126,5 +126,6 @@ Serbia,2021-08-12,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinopharm/Beijing, Sputn
 Serbia,2021-08-13,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinopharm/Beijing, Sputnik V",https://vakcinacija.gov.rs/,5626081,2872770,2753311,
 Serbia,2021-08-15,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinopharm/Beijing, Sputnik V",https://vakcinacija.gov.rs/,5632567,2875491,2757076,
 Serbia,2021-08-16,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinopharm/Beijing, Sputnik V",https://vakcinacija.gov.rs/,5640620,2878697,2761921,
-Serbia,2021-08-17,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinopharm/Beijing, Sputnik V",https://vakcinacija.gov.rs/,5649434,2881963,2766182,
-Serbia,2021-08-18,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinopharm/Beijing, Sputnik V",https://vakcinacija.gov.rs/,5656592,2884393,2768776,
+Serbia,2021-08-17,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinopharm/Beijing, Sputnik V",https://vakcinacija.gov.rs/,5649434,2881963,2766182,1289
+Serbia,2021-08-18,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinopharm/Beijing, Sputnik V",https://vakcinacija.gov.rs/,5656592,2884393,2768776,3423
+Serbia,2021-08-19,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinopharm/Beijing, Sputnik V",https://vakcinacija.gov.rs/,5670011,2887708,2771947,10356


### PR DESCRIPTION
This PR makes two changes:

1. It adds data for August 19.
2. It adds numbers of administered booster doses.

On August 17th, Serbia [started administering](https://www.srbija.gov.rs/vest/en/177106/third-dose-of-covid-19-vaccine-available-as-of-tomorrow.php) third (booster) dose. Even though number of administered booster doses is available on [vakcinacija.gov.rs](https://vakcinacija.gov.rs/), it is not in a dataset. For August 17 and August 18, I retrieved those numbers by checking search engines caches. Thankfully, they were available, so I snapshoted them for a reference: https://archive.is/JoWuK and https://archive.is/Ej7eU