### PR TITLE
Fix Taiwan: add Pfizer/BioNTech vaccine

### DIFF
--- a/scripts/output/vaccinations/main_data/Taiwan.csv
+++ b/scripts/output/vaccinations/main_data/Taiwan.csv
@@ -150,3 +150,4 @@ Taiwan,2021-09-15,"Medigen, Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/
 Taiwan,2021-09-16,"Medigen, Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,12938098,11536036,1402062
 Taiwan,2021-09-17,"Medigen, Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,13171843,11593038,1578805
 Taiwan,2021-09-21,"Medigen, Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,13405357,11689760,1715597
+Taiwan,2021-09-22,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,13589767,11763739,1826028

--- a/scripts/src/cowidev/vax/incremental/taiwan.py
+++ b/scripts/src/cowidev/vax/incremental/taiwan.py
@@ -15,6 +15,7 @@ vaccines_mapping = {
     "AstraZeneca": "Oxford/AstraZeneca",
     "高端": "Medigen",
     "Moderna": "Moderna",
+    "BioNTech": "Pfizer/BioNTech",
 }
 
 


### PR DESCRIPTION
Since today (2021/09/23) the daily pdf start to include stats for Pfizer/BioNTech vaccine which is labeled as "BioNTech".
