### PR TITLE
feat(vax,ecuador): fix vaccine mapping Cansino -> CanSino.

### DIFF
--- a/scripts/src/cowidev/vax/batch/ecuador.py
+++ b/scripts/src/cowidev/vax/batch/ecuador.py
@@ -28,7 +28,7 @@ class Ecuador:
             "Pfizer/BioNTech": "Pfizer/BioNTech",
             "Sinovac": "Sinovac",
             "Oxford/AstraZeneca": "Oxford/AstraZeneca",
-            "Cansino": "CanSino",
+            "CanSino": "CanSino",
         }
 
     def read(self) -> pd.DataFrame:


### PR DESCRIPTION
Expanding on #1976 

The vaccine `Cansino` is now being saved in our records as `CanSino`. For this reason we are opening this pull request so that the batch program doesn't try to rename the former name `Cansino`.