### PR TITLE
Vaccination : Update Antigua and Barbuda

### DIFF
--- a/scripts/output/vaccinations/main_data/Antigua and Barbuda.csv
+++ b/scripts/output/vaccinations/main_data/Antigua and Barbuda.csv
@@ -46,14 +46,14 @@ Antigua and Barbuda,2021-08-04,Oxford/AstraZeneca,https://covid19.gov.ag,69518,3
 Antigua and Barbuda,2021-08-07,Oxford/AstraZeneca,https://covid19.gov.ag,69903,38605,31298
 Antigua and Barbuda,2021-08-10,Oxford/AstraZeneca,https://covid19.gov.ag,70019,38605,31414
 Antigua and Barbuda,2021-08-14,Oxford/AstraZeneca,https://covid19.gov.ag,71065,39039,32026
-Antigua and Barbuda,2021-08-16,Oxford/AstraZeneca,https://covid19.gov.ag,71434,39186,32248
-Antigua and Barbuda,2021-08-19,Oxford/AstraZeneca,https://covid19.gov.ag,71600,39230,32370
-Antigua and Barbuda,2021-08-22,Oxford/AstraZeneca,https://covid19.gov.ag,72282,39466,32816
-Antigua and Barbuda,2021-08-24,Oxford/AstraZeneca,https://covid19.gov.ag,72902,39808,33094
-Antigua and Barbuda,2021-08-28,Oxford/AstraZeneca,https://covid19.gov.ag,73700,40309,33391
-Antigua and Barbuda,2021-08-30,Oxford/AstraZeneca,https://covid19.gov.ag,74637,40795,33842
-Antigua and Barbuda,2021-08-31,Oxford/AstraZeneca,https://covid19.gov.ag,75069,41061,34008
-Antigua and Barbuda,2021-09-07,Oxford/AstraZeneca,https://covid19.gov.ag,77997,42938,35059
-Antigua and Barbuda,2021-09-10,Oxford/AstraZeneca,https://covid19.gov.ag,79390,43681,35709
-Antigua and Barbuda,2021-09-13,Oxford/AstraZeneca,https://covid19.gov.ag,79922,43949,35973
-Antigua and Barbuda,2021-09-17,Oxford/AstraZeneca,https://covid19.gov.ag,81915,45099,36816
+Antigua and Barbuda,2021-08-16,"Oxford/AstraZeneca, Pfizer/BioNTech, Sputnik V",https://covid19.gov.ag,71434,39186,32248
+Antigua and Barbuda,2021-08-19,"Oxford/AstraZeneca, Pfizer/BioNTech, Sputnik V",https://covid19.gov.ag,71600,39230,32370
+Antigua and Barbuda,2021-08-22,"Oxford/AstraZeneca, Pfizer/BioNTech, Sputnik V",https://covid19.gov.ag,72282,39466,32816
+Antigua and Barbuda,2021-08-24,"Oxford/AstraZeneca, Pfizer/BioNTech, Sputnik V",https://covid19.gov.ag,72902,39808,33094
+Antigua and Barbuda,2021-08-28,"Oxford/AstraZeneca, Pfizer/BioNTech, Sputnik V",https://covid19.gov.ag,73700,40309,33391
+Antigua and Barbuda,2021-08-30,"Oxford/AstraZeneca, Pfizer/BioNTech, Sputnik V",https://covid19.gov.ag,74637,40795,33842
+Antigua and Barbuda,2021-08-31,"Oxford/AstraZeneca, Pfizer/BioNTech, Sputnik V",https://covid19.gov.ag,75069,41061,34008
+Antigua and Barbuda,2021-09-07,"Oxford/AstraZeneca, Pfizer/BioNTech, Sputnik V",https://covid19.gov.ag,77997,42938,35059
+Antigua and Barbuda,2021-09-10,"Oxford/AstraZeneca, Pfizer/BioNTech, Sputnik V",https://covid19.gov.ag,79390,43681,35709
+Antigua and Barbuda,2021-09-13,"Oxford/AstraZeneca, Pfizer/BioNTech, Sputnik V",https://covid19.gov.ag,79922,43949,35973
+Antigua and Barbuda,2021-09-17,"Oxford/AstraZeneca, Pfizer/BioNTech, Sputnik V",https://covid19.gov.ag,81915,45099,36816

--- a/scripts/src/cowidev/vax/incremental/antigua_barbuda.py
+++ b/scripts/src/cowidev/vax/incremental/antigua_barbuda.py
@@ -59,7 +59,7 @@ class AntiguaBarbuda:
         return enrich_data(ds, "location", self.location)
 
     def pipe_vaccine(self, ds: pd.Series) -> pd.Series:
-        return enrich_data(ds, "vaccine", "Oxford/AstraZeneca")
+        return enrich_data(ds, "vaccine", "Oxford/AstraZeneca, Pfizer/BioNTech, Sputnik V")
 
     def pipe_source(self, ds: pd.Series) -> pd.Series:
         return enrich_data(ds, "source_url", self.source_url)


### PR DESCRIPTION
Update Antigua and Barbuda

Source : https://caribbean.loopnews.com/content/antigua-barbuda-begins-roll-out-sputnik-pfizer-covid-19-vaccine