### PR TITLE
Vaccination : Burkina Faso

### DIFF
--- a/scripts/output/vaccinations/main_data/Burkina Faso.csv
+++ b/scripts/output/vaccinations/main_data/Burkina Faso.csv
@@ -4,9 +4,9 @@ Burkina Faso,2021-06-10,Oxford/AstraZeneca,https://covid19.who.int/,7881,7881,
 Burkina Faso,2021-06-14,Oxford/AstraZeneca,https://covid19.who.int/,17775,17775,
 Burkina Faso,2021-06-28,Oxford/AstraZeneca,https://covid19.who.int/,25833,25833,
 Burkina Faso,2021-07-12,Oxford/AstraZeneca,https://covid19.who.int/,33960,,
-Burkina Faso,2021-08-09,Oxford/AstraZeneca,https://covid19.who.int/,38405,38405,
-Burkina Faso,2021-08-16,Oxford/AstraZeneca,https://covid19.who.int/,71510,,
-Burkina Faso,2021-08-23,Oxford/AstraZeneca,https://covid19.who.int/,98670,77659,
-Burkina Faso,2021-08-31,Oxford/AstraZeneca,https://covid19.who.int/,108799,108799,13273
-Burkina Faso,2021-09-12,Oxford/AstraZeneca,https://covid19.who.int/,166160,166160,102268
-Burkina Faso,2021-09-22,Oxford/AstraZeneca,https://covid19.who.int/,254545,234490,168141
+Burkina Faso,2021-08-09,"Johnson&Johnson, Oxford/AstraZeneca",https://covid19.who.int/,38405,38405,
+Burkina Faso,2021-08-16,"Johnson&Johnson, Oxford/AstraZeneca",https://covid19.who.int/,71510,,
+Burkina Faso,2021-08-23,"Johnson&Johnson, Oxford/AstraZeneca",https://covid19.who.int/,98670,77659,
+Burkina Faso,2021-08-31,"Johnson&Johnson, Oxford/AstraZeneca",https://covid19.who.int/,108799,108799,13273
+Burkina Faso,2021-09-12,"Johnson&Johnson, Oxford/AstraZeneca",https://covid19.who.int/,166160,166160,102268
+Burkina Faso,2021-09-22,"Johnson&Johnson, Oxford/AstraZeneca",https://covid19.who.int/,254545,234490,168141


### PR DESCRIPTION
Update Burkina Faso

Source : https://www.africanews.com/2021/07/23/burkina-faso-receives-150-000-covid-vaccines-from-u-s//