### PR TITLE
Vaccination : Update Fiji

### DIFF
--- a/scripts/output/vaccinations/main_data/Fiji.csv
+++ b/scripts/output/vaccinations/main_data/Fiji.csv
@@ -14,12 +14,12 @@ date,people_vaccinated,people_fully_vaccinated,total_vaccinations,location,sourc
 2021-07-06,324462,54737,379199,Fiji,https://stats.pacificdata.org/vis?tm=covid&pg=0&df[ds]=SPC2&df[id]=DF_COVID_VACCINATION&df[ag]=SPC&df[vs]=1.0,Oxford/AstraZeneca
 2021-07-13,353355,66643,419998,Fiji,https://stats.pacificdata.org/vis?tm=covid&pg=0&df[ds]=SPC2&df[id]=DF_COVID_VACCINATION&df[ag]=SPC&df[vs]=1.0,Oxford/AstraZeneca
 2021-07-20,393095,78624,471719,Fiji,https://stats.pacificdata.org/vis?tm=covid&pg=0&df[ds]=SPC2&df[id]=DF_COVID_VACCINATION&df[ag]=SPC&df[vs]=1.0,Oxford/AstraZeneca
-2021-07-27,441171,97268,538439,Fiji,https://stats.pacificdata.org/vis?tm=covid&pg=0&df[ds]=SPC2&df[id]=DF_COVID_VACCINATION&df[ag]=SPC&df[vs]=1.0,Oxford/AstraZeneca
-2021-08-02,484629,144194,628823,Fiji,https://stats.pacificdata.org/vis?tm=covid&pg=0&df[ds]=SPC2&df[id]=DF_COVID_VACCINATION&df[ag]=SPC&df[vs]=1.0,Oxford/AstraZeneca
-2021-08-09,512282,178606,690888,Fiji,https://stats.pacificdata.org/vis?tm=covid&pg=0&df[ds]=SPC2&df[id]=DF_COVID_VACCINATION&df[ag]=SPC&df[vs]=1.0,Oxford/AstraZeneca
-2021-08-16,533705,211496,745201,Fiji,https://stats.pacificdata.org/vis?tm=covid&pg=0&df[ds]=SPC2&df[id]=DF_COVID_VACCINATION&df[ag]=SPC&df[vs]=1.0,Oxford/AstraZeneca
-2021-08-23,543254,234905,778159,Fiji,https://stats.pacificdata.org/vis?tm=covid&pg=0&df[ds]=SPC2&df[id]=DF_COVID_VACCINATION&df[ag]=SPC&df[vs]=1.0,Oxford/AstraZeneca
-2021-08-31,558944,266608,825552,Fiji,https://stats.pacificdata.org/vis?tm=covid&pg=0&df[ds]=SPC2&df[id]=DF_COVID_VACCINATION&df[ag]=SPC&df[vs]=1.0,Oxford/AstraZeneca
-2021-09-07,566210,299943,866153,Fiji,https://stats.pacificdata.org/vis?tm=covid&pg=0&df[ds]=SPC2&df[id]=DF_COVID_VACCINATION&df[ag]=SPC&df[vs]=1.0,Oxford/AstraZeneca
-2021-09-14,569958,342191,912149,Fiji,https://stats.pacificdata.org/vis?tm=covid&pg=0&df[ds]=SPC2&df[id]=DF_COVID_VACCINATION&df[ag]=SPC&df[vs]=1.0,Oxford/AstraZeneca
-2021-09-21,587948,387320,975268,Fiji,https://stats.pacificdata.org/vis?tm=covid&pg=0&df[ds]=SPC2&df[id]=DF_COVID_VACCINATION&df[ag]=SPC&df[vs]=1.0,Oxford/AstraZeneca
+2021-07-27,441171,97268,538439,Fiji,https://stats.pacificdata.org/vis?tm=covid&pg=0&df[ds]=SPC2&df[id]=DF_COVID_VACCINATION&df[ag]=SPC&df[vs]=1.0,"Moderna, Oxford/AstraZeneca"
+2021-08-02,484629,144194,628823,Fiji,https://stats.pacificdata.org/vis?tm=covid&pg=0&df[ds]=SPC2&df[id]=DF_COVID_VACCINATION&df[ag]=SPC&df[vs]=1.0,"Moderna, Oxford/AstraZeneca"
+2021-08-09,512282,178606,690888,Fiji,https://stats.pacificdata.org/vis?tm=covid&pg=0&df[ds]=SPC2&df[id]=DF_COVID_VACCINATION&df[ag]=SPC&df[vs]=1.0,"Moderna, Oxford/AstraZeneca"
+2021-08-16,533705,211496,745201,Fiji,https://stats.pacificdata.org/vis?tm=covid&pg=0&df[ds]=SPC2&df[id]=DF_COVID_VACCINATION&df[ag]=SPC&df[vs]=1.0,"Moderna, Oxford/AstraZeneca"
+2021-08-23,543254,234905,778159,Fiji,https://stats.pacificdata.org/vis?tm=covid&pg=0&df[ds]=SPC2&df[id]=DF_COVID_VACCINATION&df[ag]=SPC&df[vs]=1.0,"Moderna, Oxford/AstraZeneca"
+2021-08-31,558944,266608,825552,Fiji,https://stats.pacificdata.org/vis?tm=covid&pg=0&df[ds]=SPC2&df[id]=DF_COVID_VACCINATION&df[ag]=SPC&df[vs]=1.0,"Moderna, Oxford/AstraZeneca"
+2021-09-07,566210,299943,866153,Fiji,https://stats.pacificdata.org/vis?tm=covid&pg=0&df[ds]=SPC2&df[id]=DF_COVID_VACCINATION&df[ag]=SPC&df[vs]=1.0,"Moderna, Oxford/AstraZeneca"
+2021-09-14,569958,342191,912149,Fiji,https://stats.pacificdata.org/vis?tm=covid&pg=0&df[ds]=SPC2&df[id]=DF_COVID_VACCINATION&df[ag]=SPC&df[vs]=1.0,"Moderna, Oxford/AstraZeneca"
+2021-09-21,587948,387320,975268,Fiji,https://stats.pacificdata.org/vis?tm=covid&pg=0&df[ds]=SPC2&df[id]=DF_COVID_VACCINATION&df[ag]=SPC&df[vs]=1.0,"Moderna, Oxford/AstraZeneca"


### PR DESCRIPTION
Update Fiji

Source : https://www.rnz.co.nz/international/pacific-news/447293/fijians-urged-to-vaccinate-as-moderna-arrives
