### PR TITLE
Vaccination : Update Gambia

### DIFF
--- a/scripts/output/vaccinations/main_data/Gambia.csv
+++ b/scripts/output/vaccinations/main_data/Gambia.csv
@@ -12,10 +12,10 @@ Gambia,2021-06-08,"Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.who.in
 Gambia,2021-06-23,"Oxford/AstraZeneca, Sinopharm/Beijing",https://africacdc.org/covid-19-vaccination/,41077,30688,10389
 Gambia,2021-06-30,"Oxford/AstraZeneca, Sinopharm/Beijing",https://africacdc.org/covid-19-vaccination/,42975,31150,11825
 Gambia,2021-07-15,"Oxford/AstraZeneca, Sinopharm/Beijing",https://africacdc.org/covid-19-vaccination/,43557,31254,12303
-Gambia,2021-08-23,"Oxford/AstraZeneca, Sinopharm/Beijing",https://www.moh.gov.gm/wp-content/uploads/2021/08/GMB-COVID-19-Situational-Report_2021_21st_23rd_August_No-360.pdf,184553,170794,148842
-Gambia,2021-08-25,"Oxford/AstraZeneca, Sinopharm/Beijing",https://www.moh.gov.gm/wp-content/uploads/2021/08/GMB-COVID-19-Situational-Report_2021_24th_25th_August_No-361-1.pdf,191496,173810,155785
-Gambia,2021-08-28,"Oxford/AstraZeneca, Sinopharm/Beijing",https://www.moh.gov.gm/wp-content/uploads/2021/08/GMB-COVID-19-Situational-Report_2021_26th_28th_August_No-362.pdf,193532,175095,157804
-Gambia,2021-08-29,"Oxford/AstraZeneca, Sinopharm/Beijing",https://www.moh.gov.gm/wp-content/uploads/2021/09/GMB-COVID-19-Situational-Report_2021_29th_August_No-363.pdf,193961,175355,158224
-Gambia,2021-08-31,"Oxford/AstraZeneca, Sinopharm/Beijing",https://www.moh.gov.gm/wp-content/uploads/2021/09/GMB-COVID-19-Situational-Report_2021_30th_31st_August_No-364.pdf,197277,177168,161451
-Gambia,2021-09-03,"Oxford/AstraZeneca, Sinopharm/Beijing",https://www.moh.gov.gm/wp-content/uploads/2021/09/GMB-COVID-19-Situational-Report_2021_1st_3rd_September_No-365-1.pdf,199881,178634,163926
-Gambia,2021-09-07,"Oxford/AstraZeneca, Sinopharm/Beijing",https://www.moh.gov.gm/wp-content/uploads/2021/09/GMB-COVID-19-Situational-Report_2021_4th_7th_September_No-366.pdf,201835,179910,165785
+Gambia,2021-08-23,"Johnson&Johnson, Oxford/AstraZeneca, Sinopharm/Beijing",https://www.moh.gov.gm/wp-content/uploads/2021/08/GMB-COVID-19-Situational-Report_2021_21st_23rd_August_No-360.pdf,184553,170794,148842
+Gambia,2021-08-25,"Johnson&Johnson, Oxford/AstraZeneca, Sinopharm/Beijing",https://www.moh.gov.gm/wp-content/uploads/2021/08/GMB-COVID-19-Situational-Report_2021_24th_25th_August_No-361-1.pdf,191496,173810,155785
+Gambia,2021-08-28,"Johnson&Johnson, Oxford/AstraZeneca, Sinopharm/Beijing",https://www.moh.gov.gm/wp-content/uploads/2021/08/GMB-COVID-19-Situational-Report_2021_26th_28th_August_No-362.pdf,193532,175095,157804
+Gambia,2021-08-29,"Johnson&Johnson, Oxford/AstraZeneca, Sinopharm/Beijing",https://www.moh.gov.gm/wp-content/uploads/2021/09/GMB-COVID-19-Situational-Report_2021_29th_August_No-363.pdf,193961,175355,158224
+Gambia,2021-08-31,"Johnson&Johnson, Oxford/AstraZeneca, Sinopharm/Beijing",https://www.moh.gov.gm/wp-content/uploads/2021/09/GMB-COVID-19-Situational-Report_2021_30th_31st_August_No-364.pdf,197277,177168,161451
+Gambia,2021-09-03,"Johnson&Johnson, Oxford/AstraZeneca, Sinopharm/Beijing",https://www.moh.gov.gm/wp-content/uploads/2021/09/GMB-COVID-19-Situational-Report_2021_1st_3rd_September_No-365-1.pdf,199881,178634,163926
+Gambia,2021-09-07,"Johnson&Johnson, Oxford/AstraZeneca, Sinopharm/Beijing",https://www.moh.gov.gm/wp-content/uploads/2021/09/GMB-COVID-19-Situational-Report_2021_4th_7th_September_No-366.pdf,201835,179910,165785


### PR DESCRIPTION
Update Gambia

Source : https://www.aa.com.tr/en/africa/gambia-receives-over-151-000-doses-of-covid-vaccine/2324971