### PR TITLE
Vaccination : Update Nepal

### DIFF
--- a/scripts/output/vaccinations/main_data/Nepal.csv
+++ b/scripts/output/vaccinations/main_data/Nepal.csv
@@ -62,61 +62,61 @@ Nepal,2021-07-14,"Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.go
 Nepal,2021-07-16,"Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/60f15c1ba01cd_SitRep523_COVID-19_16-07-2021_EN.pdf,3885991,2765709,1120282
 Nepal,2021-07-17,"Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/60f2b4b218b38_SitRep524_COVID-19_17-07-2021_EN.pdf,4039720,2912850,1126870
 Nepal,2021-07-18,"Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/60f412032fb09_SitRep525_COVID-19_18-07-2021_EN.pdf,4129122,2999214,1129908
-Nepal,2021-07-20,"Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/60f6ac8c2b610_SitRep527_COVID-19_20-07-2021_EN.pdf,4309086,3150956,1158130
-Nepal,2021-07-22,"Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/60f94e41638f0_SitRep529_COVID-19_22-07-2021_EN.pdf,4589970,3308730,1281240
-Nepal,2021-07-23,"Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/60fa913dd42b5_SitRep530_COVID-19_23-07-2021_EN.pdf,4661963,3349951,1312012
-Nepal,2021-07-24,"Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/60fbedb57b1d3_SitRep531_COVID-19_24-07-2021_EN.pdf,4743274,3377228,1366046
-Nepal,2021-07-25,"Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/60fd49e53adf2_SitRep532_COVID-19_25-07-2021_EN.pdf,4781216,3383038,1398178
-Nepal,2021-07-26,"Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/60fe91418b3d8_SitRep533_COVID-19_26-07-2021_EN.pdf,4828570,3405154,1423416
-Nepal,2021-07-27,"Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/60ffdfab16c98_SitRep534_COVID-19_27-07-2021_EN.pdf,4920010,3462340,1457670
-Nepal,2021-07-28,"Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/61013c63c1bb2_SitRep535_COVID-19_28-07-2021_EN.pdf,5047355,3544043,1503312
-Nepal,2021-07-29,"Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/6102833497a5e_SitRep536_COVID-19_29-07-2021_EN.pdf,5199536,3650733,1548803
-Nepal,2021-07-31,"Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/61052a976f2e3_SitRep538_COVID-19_31-07-2021_EN.pdf,5682627,3936724,1745903
-Nepal,2021-08-01,"Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/61067b0bc4bab_SitRep539_COVID-19_01-08-2021_EN.pdf,5877759,4064288,1813471
-Nepal,2021-08-02,"Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/6107d17cd2d05_SitRep540_COVID-19_02-08-2021_EN.pdf,6163462,4163251,2000211
-Nepal,2021-08-03,"Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/610930421a0ea_SitRep541_COVID-19_03-08-2021_EN.pdf,6257243,4254540,2002703
-Nepal,2021-08-04,"Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/610a77d23f34a_SitRep542_COVID-19_04-08-2021_EN.pdf,6372398,4297612,2074786
-Nepal,2021-08-05,"Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/610bc1d54574b_SitRep543_COVID-19_05-08-2021_EN.pdf,6490177,4359277,2130900
-Nepal,2021-08-06,"Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/610d1dec4f07e_SitRep544_COVID-19_06-08-2021_EN.pdf,6611076,4403021,2208055
-Nepal,2021-08-07,"Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/610e684798d46_SitRep545_COVID-19_07-08-2021_EN.pdf,6802415,4442622,2359793
-Nepal,2021-08-08,"Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/610faf990be96_SitRep546_COVID-19_08-08-2021_EN.pdf,6986451,4494269,2492182
-Nepal,2021-08-09,"Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/611117b210973_SitRep547_COVID-19_09-08-2021_EN.pdf,7131481,4525435,2606046
-Nepal,2021-08-10,"Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/611260b20167c_SitRep548_COVID-19_10-08-2021_EN.pdf,7263702,4541682,2722020
-Nepal,2021-08-11,"Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/6113b3e429294_SitRep549_COVID-19_11-08-2021_EN.pdf,7458913,4570553,2888360
-Nepal,2021-08-12,"Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/6115077d6b9c2_SitRep550_COVID-19_12-08-2021_EN.pdf,7515766,4593526,2922240
-Nepal,2021-08-14,"Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/611795d604c7c_SitRep552_COVID-19_14-08-2021_EN.pdf,7977896,4674318,3303578
-Nepal,2021-08-15,"Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/6118f29c908cf_SitRep553_COVID-19_15-08-2021_EN.pdf,8048666,4684509,3364157
-Nepal,2021-08-16,"Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/611a3fb60790a_SitRep554_COVID-19_16-08-2021_EN.pdf,8207001,4716936,3490065
-Nepal,2021-08-17,"Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/611ba16723b67_SitRep555_COVID-19_17-08-2021_EN.pdf,8351529,4764856,3586673
-Nepal,2021-08-18,"Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/611cefc71ff90_SitRep556_COVID-19_18-08-2021_EN.pdf,8435662,4785902,3649760
-Nepal,2021-08-19,"Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/611e3a2f0a643_SitRep557_COVID-19_19-08-2021_EN.pdf,8526673,4817985,3708688
-Nepal,2021-08-20,"Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/611f86231479d_SitRep558_COVID-19_20-08-2021_EN.pdf,8706701,4907523,3799178
-Nepal,2021-08-21,"Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/6120d99ad1248_SitRep559_COVID-19_21-08-2021_EN.pdf,8770664,4935056,3835608
-Nepal,2021-08-22,"Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/6122288637f6a_SitRep560_COVID-19_22-08-2021_EN.pdf,8788986,4942250,3846736
-Nepal,2021-08-23,"Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/612387a085ece_SitRep561_COVID-19_23-08-2021_EN.pdf,8801330,4943732,3857598
-Nepal,2021-08-25,"Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/612625584816e_SitRep563_COVID-19_25-08-2021_EN.pdf,8866396,4956455,3909941
-Nepal,2021-08-26,"Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/6127790a38080_SitRep564_COVID-19_26-08-2021_EN.pdf,8936422,4986893,3949529
-Nepal,2021-08-27,"Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/6128bb18f0f0c_SitRep565_COVID-19_27-08-2021_EN.pdf,9116287,5063522,4052765
-Nepal,2021-08-30,"Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/612cb51d3fe6b_SitRep568_COVID-19_30-08-2021_EN.pdf,9713885,5317483,4396402
-Nepal,2021-08-31,"Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/612e113c20d8a_SitRep569_COVID-19_31-08-2021_EN.pdf,9799013,5339252,4459761
-Nepal,2021-09-01,"Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/612f66c750fc6_SitRep570_COVID-19_01-09-2021_EN.pdf,10092164,5424836,4667328
-Nepal,2021-09-02,"Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/6130ad5b729bf_SitRep571_COVID-19_02-09-2021_EN.pdf,10103864,5425888,4677976
-Nepal,2021-09-03,"Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/6131f7428276d_SitRep572_COVID-19_03-09-2021_EN.pdf,10268166,5472793,4795373
-Nepal,2021-09-04,"Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/61334b8ac5655_SitRep573_COVID-19_04-09-2021_EN.pdf,10375764,5511929,4863835
-Nepal,2021-09-05,"Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/61349d3f9599d_SitRep574_COVID-19_05-09-2021_EN.pdf,10428946,5533794,4895152
-Nepal,2021-09-06,"Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/6135f594ced0d_SitRep575_COVID-19_06-09-2021_EN.pdf,10536178,5573419,4962759
-Nepal,2021-09-07,"Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/61373f6f4baeb_SitRep576_COVID-19_07-09-2021_EN.pdf,10616578,5603757,5012821
-Nepal,2021-09-09,"Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/6139e42bc566b_SitRep578_COVID-19_09-09-2021_EN.pdf,10832033,5729789,5102244
-Nepal,2021-09-10,"Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/613b2e55b3813_SitRep579_COVID-19_10-09-2021_EN.pdf,10861222,5740345,5120877
-Nepal,2021-09-11,"Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/613c86ea5b496_SitRep580_COVID-19_11-09-2021_EN.pdf,10929852,5769328,5160524
-Nepal,2021-09-12,"Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/613dd320c91dc_SitRep581_COVID-19_12-09-2021_EN.pdf,10940301,5773612,5166689
-Nepal,2021-09-13,"Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/613f237c3f8e4_SitRep582_COVID-19_13-09-2021_EN.pdf,11032131,5833938,5198193
-Nepal,2021-09-14,"Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/61407f1ccfdeb_SitRep583_COVID-19_14-09-2021_EN.pdf,11120315,5877079,5243236
-Nepal,2021-09-15,"Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/6141dd3ad14bb_SitRep584_COVID-19_15-09-2021_EN.pdf,11419446,6004019,5415427
-Nepal,2021-09-16,"Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/6143240e59c19_SitRep585_COVID-19_16-09-2021_EN.pdf,11530345,6057194,5473151
-Nepal,2021-09-17,"Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/61446a7ed507c_SitRep586_COVID-19_17-09-2021_EN.pdf,11590504,6083124,5507380
-Nepal,2021-09-18,"Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/6145cb20cf893_SitRep587_COVID-19_18-09-2021_EN.pdf,11760821,6198936,5561885
-Nepal,2021-09-19,"Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/614712704068a_SitRep588_COVID-19_19-09-2021_EN.pdf,11782181,6203316,5578865
-Nepal,2021-09-22,"Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/614b0b39e5eea_SitRep591_COVID-19_22-09-2021_EN.pdf,12015633,6262780,5752853
-Nepal,2021-09-23,"Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/614c5403ba6f5_SitRep592_COVID-19_23-09-2021_EN.pdf,12154018,6293089,5860929
-Nepal,2021-09-24,"Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/614daed348715_SitRep593_COVID-19_24-09-2021_EN.pdf,12326608,6380586,5946022
+Nepal,2021-07-20,"Johnson&Johnson, Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/60f6ac8c2b610_SitRep527_COVID-19_20-07-2021_EN.pdf,4309086,3150956,1158130
+Nepal,2021-07-22,"Johnson&Johnson, Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/60f94e41638f0_SitRep529_COVID-19_22-07-2021_EN.pdf,4589970,3308730,1281240
+Nepal,2021-07-23,"Johnson&Johnson, Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/60fa913dd42b5_SitRep530_COVID-19_23-07-2021_EN.pdf,4661963,3349951,1312012
+Nepal,2021-07-24,"Johnson&Johnson, Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/60fbedb57b1d3_SitRep531_COVID-19_24-07-2021_EN.pdf,4743274,3377228,1366046
+Nepal,2021-07-25,"Johnson&Johnson, Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/60fd49e53adf2_SitRep532_COVID-19_25-07-2021_EN.pdf,4781216,3383038,1398178
+Nepal,2021-07-26,"Johnson&Johnson, Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/60fe91418b3d8_SitRep533_COVID-19_26-07-2021_EN.pdf,4828570,3405154,1423416
+Nepal,2021-07-27,"Johnson&Johnson, Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/60ffdfab16c98_SitRep534_COVID-19_27-07-2021_EN.pdf,4920010,3462340,1457670
+Nepal,2021-07-28,"Johnson&Johnson, Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/61013c63c1bb2_SitRep535_COVID-19_28-07-2021_EN.pdf,5047355,3544043,1503312
+Nepal,2021-07-29,"Johnson&Johnson, Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/6102833497a5e_SitRep536_COVID-19_29-07-2021_EN.pdf,5199536,3650733,1548803
+Nepal,2021-07-31,"Johnson&Johnson, Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/61052a976f2e3_SitRep538_COVID-19_31-07-2021_EN.pdf,5682627,3936724,1745903
+Nepal,2021-08-01,"Johnson&Johnson, Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/61067b0bc4bab_SitRep539_COVID-19_01-08-2021_EN.pdf,5877759,4064288,1813471
+Nepal,2021-08-02,"Johnson&Johnson, Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/6107d17cd2d05_SitRep540_COVID-19_02-08-2021_EN.pdf,6163462,4163251,2000211
+Nepal,2021-08-03,"Johnson&Johnson, Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/610930421a0ea_SitRep541_COVID-19_03-08-2021_EN.pdf,6257243,4254540,2002703
+Nepal,2021-08-04,"Johnson&Johnson, Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/610a77d23f34a_SitRep542_COVID-19_04-08-2021_EN.pdf,6372398,4297612,2074786
+Nepal,2021-08-05,"Johnson&Johnson, Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/610bc1d54574b_SitRep543_COVID-19_05-08-2021_EN.pdf,6490177,4359277,2130900
+Nepal,2021-08-06,"Johnson&Johnson, Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/610d1dec4f07e_SitRep544_COVID-19_06-08-2021_EN.pdf,6611076,4403021,2208055
+Nepal,2021-08-07,"Johnson&Johnson, Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/610e684798d46_SitRep545_COVID-19_07-08-2021_EN.pdf,6802415,4442622,2359793
+Nepal,2021-08-08,"Johnson&Johnson, Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/610faf990be96_SitRep546_COVID-19_08-08-2021_EN.pdf,6986451,4494269,2492182
+Nepal,2021-08-09,"Johnson&Johnson, Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/611117b210973_SitRep547_COVID-19_09-08-2021_EN.pdf,7131481,4525435,2606046
+Nepal,2021-08-10,"Johnson&Johnson, Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/611260b20167c_SitRep548_COVID-19_10-08-2021_EN.pdf,7263702,4541682,2722020
+Nepal,2021-08-11,"Johnson&Johnson, Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/6113b3e429294_SitRep549_COVID-19_11-08-2021_EN.pdf,7458913,4570553,2888360
+Nepal,2021-08-12,"Johnson&Johnson, Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/6115077d6b9c2_SitRep550_COVID-19_12-08-2021_EN.pdf,7515766,4593526,2922240
+Nepal,2021-08-14,"Johnson&Johnson, Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/611795d604c7c_SitRep552_COVID-19_14-08-2021_EN.pdf,7977896,4674318,3303578
+Nepal,2021-08-15,"Johnson&Johnson, Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/6118f29c908cf_SitRep553_COVID-19_15-08-2021_EN.pdf,8048666,4684509,3364157
+Nepal,2021-08-16,"Johnson&Johnson, Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/611a3fb60790a_SitRep554_COVID-19_16-08-2021_EN.pdf,8207001,4716936,3490065
+Nepal,2021-08-17,"Johnson&Johnson, Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/611ba16723b67_SitRep555_COVID-19_17-08-2021_EN.pdf,8351529,4764856,3586673
+Nepal,2021-08-18,"Johnson&Johnson, Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/611cefc71ff90_SitRep556_COVID-19_18-08-2021_EN.pdf,8435662,4785902,3649760
+Nepal,2021-08-19,"Johnson&Johnson, Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/611e3a2f0a643_SitRep557_COVID-19_19-08-2021_EN.pdf,8526673,4817985,3708688
+Nepal,2021-08-20,"Johnson&Johnson, Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/611f86231479d_SitRep558_COVID-19_20-08-2021_EN.pdf,8706701,4907523,3799178
+Nepal,2021-08-21,"Johnson&Johnson, Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/6120d99ad1248_SitRep559_COVID-19_21-08-2021_EN.pdf,8770664,4935056,3835608
+Nepal,2021-08-22,"Johnson&Johnson, Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/6122288637f6a_SitRep560_COVID-19_22-08-2021_EN.pdf,8788986,4942250,3846736
+Nepal,2021-08-23,"Johnson&Johnson, Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/612387a085ece_SitRep561_COVID-19_23-08-2021_EN.pdf,8801330,4943732,3857598
+Nepal,2021-08-25,"Johnson&Johnson, Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/612625584816e_SitRep563_COVID-19_25-08-2021_EN.pdf,8866396,4956455,3909941
+Nepal,2021-08-26,"Johnson&Johnson, Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/6127790a38080_SitRep564_COVID-19_26-08-2021_EN.pdf,8936422,4986893,3949529
+Nepal,2021-08-27,"Johnson&Johnson, Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/6128bb18f0f0c_SitRep565_COVID-19_27-08-2021_EN.pdf,9116287,5063522,4052765
+Nepal,2021-08-30,"Johnson&Johnson, Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/612cb51d3fe6b_SitRep568_COVID-19_30-08-2021_EN.pdf,9713885,5317483,4396402
+Nepal,2021-08-31,"Johnson&Johnson, Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/612e113c20d8a_SitRep569_COVID-19_31-08-2021_EN.pdf,9799013,5339252,4459761
+Nepal,2021-09-01,"Johnson&Johnson, Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/612f66c750fc6_SitRep570_COVID-19_01-09-2021_EN.pdf,10092164,5424836,4667328
+Nepal,2021-09-02,"Johnson&Johnson, Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/6130ad5b729bf_SitRep571_COVID-19_02-09-2021_EN.pdf,10103864,5425888,4677976
+Nepal,2021-09-03,"Johnson&Johnson, Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/6131f7428276d_SitRep572_COVID-19_03-09-2021_EN.pdf,10268166,5472793,4795373
+Nepal,2021-09-04,"Johnson&Johnson, Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/61334b8ac5655_SitRep573_COVID-19_04-09-2021_EN.pdf,10375764,5511929,4863835
+Nepal,2021-09-05,"Johnson&Johnson, Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/61349d3f9599d_SitRep574_COVID-19_05-09-2021_EN.pdf,10428946,5533794,4895152
+Nepal,2021-09-06,"Johnson&Johnson, Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/6135f594ced0d_SitRep575_COVID-19_06-09-2021_EN.pdf,10536178,5573419,4962759
+Nepal,2021-09-07,"Johnson&Johnson, Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/61373f6f4baeb_SitRep576_COVID-19_07-09-2021_EN.pdf,10616578,5603757,5012821
+Nepal,2021-09-09,"Johnson&Johnson, Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/6139e42bc566b_SitRep578_COVID-19_09-09-2021_EN.pdf,10832033,5729789,5102244
+Nepal,2021-09-10,"Johnson&Johnson, Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/613b2e55b3813_SitRep579_COVID-19_10-09-2021_EN.pdf,10861222,5740345,5120877
+Nepal,2021-09-11,"Johnson&Johnson, Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/613c86ea5b496_SitRep580_COVID-19_11-09-2021_EN.pdf,10929852,5769328,5160524
+Nepal,2021-09-12,"Johnson&Johnson, Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/613dd320c91dc_SitRep581_COVID-19_12-09-2021_EN.pdf,10940301,5773612,5166689
+Nepal,2021-09-13,"Johnson&Johnson, Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/613f237c3f8e4_SitRep582_COVID-19_13-09-2021_EN.pdf,11032131,5833938,5198193
+Nepal,2021-09-14,"Johnson&Johnson, Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/61407f1ccfdeb_SitRep583_COVID-19_14-09-2021_EN.pdf,11120315,5877079,5243236
+Nepal,2021-09-15,"Johnson&Johnson, Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/6141dd3ad14bb_SitRep584_COVID-19_15-09-2021_EN.pdf,11419446,6004019,5415427
+Nepal,2021-09-16,"Johnson&Johnson, Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/6143240e59c19_SitRep585_COVID-19_16-09-2021_EN.pdf,11530345,6057194,5473151
+Nepal,2021-09-17,"Johnson&Johnson, Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/61446a7ed507c_SitRep586_COVID-19_17-09-2021_EN.pdf,11590504,6083124,5507380
+Nepal,2021-09-18,"Johnson&Johnson, Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/6145cb20cf893_SitRep587_COVID-19_18-09-2021_EN.pdf,11760821,6198936,5561885
+Nepal,2021-09-19,"Johnson&Johnson, Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/614712704068a_SitRep588_COVID-19_19-09-2021_EN.pdf,11782181,6203316,5578865
+Nepal,2021-09-22,"Johnson&Johnson, Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/614b0b39e5eea_SitRep591_COVID-19_22-09-2021_EN.pdf,12015633,6262780,5752853
+Nepal,2021-09-23,"Johnson&Johnson, Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/614c5403ba6f5_SitRep592_COVID-19_23-09-2021_EN.pdf,12154018,6293089,5860929
+Nepal,2021-09-24,"Johnson&Johnson, Oxford/AstraZeneca, Sinopharm/Beijing",https://covid19.mohp.gov.np/covid/englishSituationReport/614daed348715_SitRep593_COVID-19_24-09-2021_EN.pdf,12326608,6380586,5946022


### PR DESCRIPTION
Update Nepal

Source : https://thehimalayantimes.com/nepal/nepal-begins-inoculation-of-single-shot-jj-vaccine-starting-today