### PR TITLE
Vaccination : Update Saint Lucia

### DIFF
--- a/scripts/output/vaccinations/main_data/Saint Lucia.csv
+++ b/scripts/output/vaccinations/main_data/Saint Lucia.csv
@@ -81,20 +81,20 @@ Saint Lucia,2021-08-11,Oxford/AstraZeneca,59051,33120,25931,https://www.covid19r
 Saint Lucia,2021-08-12,Oxford/AstraZeneca,59319,33256,26063,https://www.covid19response.lc/
 Saint Lucia,2021-08-13,Oxford/AstraZeneca,59537,33474,26063,https://www.covid19response.lc/
 Saint Lucia,2021-08-17,Oxford/AstraZeneca,60032,33702,26330,https://www.covid19response.lc/
-Saint Lucia,2021-08-19,Oxford/AstraZeneca,61015,34195,26820,https://www.covid19response.lc/
-Saint Lucia,2021-08-20,Oxford/AstraZeneca,61566,34464,27102,https://www.covid19response.lc/
-Saint Lucia,2021-08-21,Oxford/AstraZeneca,61823,34601,27222,https://www.covid19response.lc/
-Saint Lucia,2021-08-22,Oxford/AstraZeneca,61857,34621,27236,https://www.covid19response.lc/
-Saint Lucia,2021-08-24,Oxford/AstraZeneca,62165,34888,27277,https://www.covid19response.lc/
-Saint Lucia,2021-08-26,Oxford/AstraZeneca,63262,35707,27555,https://www.covid19response.lc/
-Saint Lucia,2021-08-27,Oxford/AstraZeneca,63874,36203,27671,https://www.covid19response.lc/
-Saint Lucia,2021-08-28,Oxford/AstraZeneca,64382,36623,27759,https://www.covid19response.lc/
-Saint Lucia,2021-08-30,Oxford/AstraZeneca,64523,36750,27773,https://www.covid19response.lc/
-Saint Lucia,2021-09-15,Oxford/AstraZeneca,70929,42145,28784,https://www.covid19response.lc/
-Saint Lucia,2021-09-16,Oxford/AstraZeneca,71517,42594,28923,https://www.covid19response.lc/
-Saint Lucia,2021-09-18,Oxford/AstraZeneca,72370,43264,29106,https://www.covid19response.lc/
-Saint Lucia,2021-09-19,Oxford/AstraZeneca,72577,43431,29146,https://www.covid19response.lc/
-Saint Lucia,2021-09-21,Oxford/AstraZeneca,72947,43582,29365,https://www.covid19response.lc/
-Saint Lucia,2021-09-22,Oxford/AstraZeneca,73738,43946,29792,https://www.covid19response.lc/
-Saint Lucia,2021-09-23,Oxford/AstraZeneca,74492,44292,30200,https://www.covid19response.lc/
-Saint Lucia,2021-09-24,Oxford/AstraZeneca,74999,44516,30483,https://www.covid19response.lc/
+Saint Lucia,2021-08-19,"Oxford/AstraZeneca, Pfizer/BioNTech",61015,34195,26820,https://www.covid19response.lc/
+Saint Lucia,2021-08-20,"Oxford/AstraZeneca, Pfizer/BioNTech",61566,34464,27102,https://www.covid19response.lc/
+Saint Lucia,2021-08-21,"Oxford/AstraZeneca, Pfizer/BioNTech",61823,34601,27222,https://www.covid19response.lc/
+Saint Lucia,2021-08-22,"Oxford/AstraZeneca, Pfizer/BioNTech",61857,34621,27236,https://www.covid19response.lc/
+Saint Lucia,2021-08-24,"Oxford/AstraZeneca, Pfizer/BioNTech",62165,34888,27277,https://www.covid19response.lc/
+Saint Lucia,2021-08-26,"Oxford/AstraZeneca, Pfizer/BioNTech",63262,35707,27555,https://www.covid19response.lc/
+Saint Lucia,2021-08-27,"Oxford/AstraZeneca, Pfizer/BioNTech",63874,36203,27671,https://www.covid19response.lc/
+Saint Lucia,2021-08-28,"Oxford/AstraZeneca, Pfizer/BioNTech",64382,36623,27759,https://www.covid19response.lc/
+Saint Lucia,2021-08-30,"Oxford/AstraZeneca, Pfizer/BioNTech",64523,36750,27773,https://www.covid19response.lc/
+Saint Lucia,2021-09-15,"Oxford/AstraZeneca, Pfizer/BioNTech",70929,42145,28784,https://www.covid19response.lc/
+Saint Lucia,2021-09-16,"Oxford/AstraZeneca, Pfizer/BioNTech",71517,42594,28923,https://www.covid19response.lc/
+Saint Lucia,2021-09-18,"Oxford/AstraZeneca, Pfizer/BioNTech",72370,43264,29106,https://www.covid19response.lc/
+Saint Lucia,2021-09-19,"Oxford/AstraZeneca, Pfizer/BioNTech",72577,43431,29146,https://www.covid19response.lc/
+Saint Lucia,2021-09-21,"Oxford/AstraZeneca, Pfizer/BioNTech",72947,43582,29365,https://www.covid19response.lc/
+Saint Lucia,2021-09-22,"Oxford/AstraZeneca, Pfizer/BioNTech",73738,43946,29792,https://www.covid19response.lc/
+Saint Lucia,2021-09-23,"Oxford/AstraZeneca, Pfizer/BioNTech",74492,44292,30200,https://www.covid19response.lc/
+Saint Lucia,2021-09-24,"Oxford/AstraZeneca, Pfizer/BioNTech",74999,44516,30483,https://www.covid19response.lc/

--- a/scripts/src/cowidev/vax/incremental/saint_lucia.py
+++ b/scripts/src/cowidev/vax/incremental/saint_lucia.py
@@ -41,7 +41,7 @@ def enrich_location(ds: pd.Series) -> pd.Series:
 
 
 def enrich_vaccine(ds: pd.Series) -> pd.Series:
-    return enrich_data(ds, "vaccine", "Oxford/AstraZeneca")
+    return enrich_data(ds, "vaccine", "Oxford/AstraZeneca, Pfizer/BioNTech")
 
 
 def enrich_source(ds: pd.Series) -> pd.Series:


### PR DESCRIPTION
Update Saint Lucia

Source : https://bb.usembassy.gov/united-states-delivers-52650-pfizer-vaccines-to-saint-lucia/