### PR TITLE
Vaccination : Update Trinidad and Tobago

### DIFF
--- a/scripts/output/vaccinations/main_data/Trinidad and Tobago.csv
+++ b/scripts/output/vaccinations/main_data/Trinidad and Tobago.csv
@@ -122,47 +122,47 @@ date,people_vaccinated,people_fully_vaccinated,total_vaccinations,location,vacci
 2021-08-09,418721,230454.0,649175.0,Trinidad and Tobago,"Oxford/AstraZeneca, Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
 2021-08-10,425422,242543.0,667965.0,Trinidad and Tobago,"Oxford/AstraZeneca, Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
 2021-08-11,432806,255138.0,687944.0,Trinidad and Tobago,"Oxford/AstraZeneca, Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
-2021-08-12,438310,271653.0,709963.0,Trinidad and Tobago,"Oxford/AstraZeneca, Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
-2021-08-13,444308,284572.0,728880.0,Trinidad and Tobago,"Oxford/AstraZeneca, Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
-2021-08-14,449021,292963.0,741984.0,Trinidad and Tobago,"Oxford/AstraZeneca, Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
-2021-08-15,452509,308205.0,760714.0,Trinidad and Tobago,"Oxford/AstraZeneca, Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
-2021-08-16,454088,320425.0,774513.0,Trinidad and Tobago,"Oxford/AstraZeneca, Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
-2021-08-17,457991,329737.0,787728.0,Trinidad and Tobago,"Oxford/AstraZeneca, Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
-2021-08-18,461528,339267.0,800795.0,Trinidad and Tobago,"Oxford/AstraZeneca, Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
-2021-08-19,467029,346441.0,813470.0,Trinidad and Tobago,"Oxford/AstraZeneca, Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
-2021-08-20,472946,355822.0,828768.0,Trinidad and Tobago,"Oxford/AstraZeneca, Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
-2021-08-21,479626,364579.0,844205.0,Trinidad and Tobago,"Oxford/AstraZeneca, Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
-2021-08-22,483269,367691.0,850960.0,Trinidad and Tobago,"Oxford/AstraZeneca, Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
-2021-08-23,486399,369324.0,855723.0,Trinidad and Tobago,"Oxford/AstraZeneca, Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
-2021-08-24,490958,372614.0,863572.0,Trinidad and Tobago,"Oxford/AstraZeneca, Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
-2021-08-25,494625,377398.0,872023.0,Trinidad and Tobago,"Oxford/AstraZeneca, Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
-2021-08-26,498016,381791.0,879807.0,Trinidad and Tobago,"Oxford/AstraZeneca, Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
-2021-08-27,500623,385589.0,886212.0,Trinidad and Tobago,"Oxford/AstraZeneca, Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
-2021-08-28,503239,390380.0,893619.0,Trinidad and Tobago,"Oxford/AstraZeneca, Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
-2021-08-29,505067,393916.0,898983.0,Trinidad and Tobago,"Oxford/AstraZeneca, Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
-2021-08-30,506676,395743.0,902419.0,Trinidad and Tobago,"Oxford/AstraZeneca, Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
-2021-08-31,509516,399116.0,908632.0,Trinidad and Tobago,"Oxford/AstraZeneca, Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
-2021-09-01,510548,400054.0,910602.0,Trinidad and Tobago,"Oxford/AstraZeneca, Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
-2021-09-02,513448,404221.0,917669.0,Trinidad and Tobago,"Oxford/AstraZeneca, Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
-2021-09-03,515595,408058.0,923653.0,Trinidad and Tobago,"Oxford/AstraZeneca, Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
-2021-09-04,517798,411817.0,929615.0,Trinidad and Tobago,"Oxford/AstraZeneca, Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
-2021-09-05,521770,413096.0,934866.0,Trinidad and Tobago,"Oxford/AstraZeneca, Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
-2021-09-06,523198,413737.0,936935.0,Trinidad and Tobago,"Oxford/AstraZeneca, Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
-2021-09-07,528017,417358.0,945375.0,Trinidad and Tobago,"Oxford/AstraZeneca, Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
-2021-09-08,532484,420686.0,953170.0,Trinidad and Tobago,"Oxford/AstraZeneca, Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
-2021-09-09,536524,425763.0,962287.0,Trinidad and Tobago,"Oxford/AstraZeneca, Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
-2021-09-10,539607,431229.0,970836.0,Trinidad and Tobago,"Oxford/AstraZeneca, Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
-2021-09-11,543072,438491.0,981563.0,Trinidad and Tobago,"Oxford/AstraZeneca, Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
-2021-09-12,544602,441540.0,986142.0,Trinidad and Tobago,"Oxford/AstraZeneca, Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
-2021-09-13,545725,443563.0,989288.0,Trinidad and Tobago,"Oxford/AstraZeneca, Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
-2021-09-14,548713,448802.0,997515.0,Trinidad and Tobago,"Oxford/AstraZeneca, Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
-2021-09-15,551160,452934.0,1004094.0,Trinidad and Tobago,"Oxford/AstraZeneca, Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
-2021-09-16,553390,456483.0,1009873.0,Trinidad and Tobago,"Oxford/AstraZeneca, Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
-2021-09-17,555534,459411.0,1014945.0,Trinidad and Tobago,"Oxford/AstraZeneca, Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
-2021-09-18,557693,462338.0,1020031.0,Trinidad and Tobago,"Oxford/AstraZeneca, Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
-2021-09-19,558486,463504.0,1021990.0,Trinidad and Tobago,"Oxford/AstraZeneca, Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
-2021-09-20,558811,464129.0,1022940.0,Trinidad and Tobago,"Oxford/AstraZeneca, Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
-2021-09-21,560725,467790.0,1028515.0,Trinidad and Tobago,"Oxford/AstraZeneca, Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
-2021-09-22,562582,470075.0,1032657.0,Trinidad and Tobago,"Oxford/AstraZeneca, Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
-2021-09-23,564315,473097.0,1037412.0,Trinidad and Tobago,"Oxford/AstraZeneca, Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
-2021-09-24,565940,475896.0,1041836.0,Trinidad and Tobago,"Oxford/AstraZeneca, Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
+2021-08-12,438310,271653.0,709963.0,Trinidad and Tobago,"Oxford/AstraZeneca, Pfizer/BioNTech Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
+2021-08-13,444308,284572.0,728880.0,Trinidad and Tobago,"Oxford/AstraZeneca, Pfizer/BioNTech Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
+2021-08-14,449021,292963.0,741984.0,Trinidad and Tobago,"Oxford/AstraZeneca, Pfizer/BioNTech Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
+2021-08-15,452509,308205.0,760714.0,Trinidad and Tobago,"Oxford/AstraZeneca, Pfizer/BioNTech Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
+2021-08-16,454088,320425.0,774513.0,Trinidad and Tobago,"Oxford/AstraZeneca, Pfizer/BioNTech Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
+2021-08-17,457991,329737.0,787728.0,Trinidad and Tobago,"Oxford/AstraZeneca, Pfizer/BioNTech Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
+2021-08-18,461528,339267.0,800795.0,Trinidad and Tobago,"Oxford/AstraZeneca, Pfizer/BioNTech Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
+2021-08-19,467029,346441.0,813470.0,Trinidad and Tobago,"Oxford/AstraZeneca, Pfizer/BioNTech Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
+2021-08-20,472946,355822.0,828768.0,Trinidad and Tobago,"Oxford/AstraZeneca, Pfizer/BioNTech Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
+2021-08-21,479626,364579.0,844205.0,Trinidad and Tobago,"Oxford/AstraZeneca, Pfizer/BioNTech Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
+2021-08-22,483269,367691.0,850960.0,Trinidad and Tobago,"Oxford/AstraZeneca, Pfizer/BioNTech Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
+2021-08-23,486399,369324.0,855723.0,Trinidad and Tobago,"Oxford/AstraZeneca, Pfizer/BioNTech Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
+2021-08-24,490958,372614.0,863572.0,Trinidad and Tobago,"Oxford/AstraZeneca, Pfizer/BioNTech Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
+2021-08-25,494625,377398.0,872023.0,Trinidad and Tobago,"Oxford/AstraZeneca, Pfizer/BioNTech Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
+2021-08-26,498016,381791.0,879807.0,Trinidad and Tobago,"Oxford/AstraZeneca, Pfizer/BioNTech Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
+2021-08-27,500623,385589.0,886212.0,Trinidad and Tobago,"Oxford/AstraZeneca, Pfizer/BioNTech Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
+2021-08-28,503239,390380.0,893619.0,Trinidad and Tobago,"Oxford/AstraZeneca, Pfizer/BioNTech Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
+2021-08-29,505067,393916.0,898983.0,Trinidad and Tobago,"Oxford/AstraZeneca, Pfizer/BioNTech Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
+2021-08-30,506676,395743.0,902419.0,Trinidad and Tobago,"Oxford/AstraZeneca, Pfizer/BioNTech Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
+2021-08-31,509516,399116.0,908632.0,Trinidad and Tobago,"Oxford/AstraZeneca, Pfizer/BioNTech Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
+2021-09-01,510548,400054.0,910602.0,Trinidad and Tobago,"Oxford/AstraZeneca, Pfizer/BioNTech Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
+2021-09-02,513448,404221.0,917669.0,Trinidad and Tobago,"Oxford/AstraZeneca, Pfizer/BioNTech Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
+2021-09-03,515595,408058.0,923653.0,Trinidad and Tobago,"Oxford/AstraZeneca, Pfizer/BioNTech Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
+2021-09-04,517798,411817.0,929615.0,Trinidad and Tobago,"Oxford/AstraZeneca, Pfizer/BioNTech Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
+2021-09-05,521770,413096.0,934866.0,Trinidad and Tobago,"Oxford/AstraZeneca, Pfizer/BioNTech Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
+2021-09-06,523198,413737.0,936935.0,Trinidad and Tobago,"Oxford/AstraZeneca, Pfizer/BioNTech Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
+2021-09-07,528017,417358.0,945375.0,Trinidad and Tobago,"Oxford/AstraZeneca, Pfizer/BioNTech Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
+2021-09-08,532484,420686.0,953170.0,Trinidad and Tobago,"Oxford/AstraZeneca, Pfizer/BioNTech Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
+2021-09-09,536524,425763.0,962287.0,Trinidad and Tobago,"Oxford/AstraZeneca, Pfizer/BioNTech Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
+2021-09-10,539607,431229.0,970836.0,Trinidad and Tobago,"Oxford/AstraZeneca, Pfizer/BioNTech Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
+2021-09-11,543072,438491.0,981563.0,Trinidad and Tobago,"Oxford/AstraZeneca, Pfizer/BioNTech Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
+2021-09-12,544602,441540.0,986142.0,Trinidad and Tobago,"Oxford/AstraZeneca, Pfizer/BioNTech Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
+2021-09-13,545725,443563.0,989288.0,Trinidad and Tobago,"Oxford/AstraZeneca, Pfizer/BioNTech Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
+2021-09-14,548713,448802.0,997515.0,Trinidad and Tobago,"Oxford/AstraZeneca, Pfizer/BioNTech Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
+2021-09-15,551160,452934.0,1004094.0,Trinidad and Tobago,"Oxford/AstraZeneca, Pfizer/BioNTech Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
+2021-09-16,553390,456483.0,1009873.0,Trinidad and Tobago,"Oxford/AstraZeneca, Pfizer/BioNTech Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
+2021-09-17,555534,459411.0,1014945.0,Trinidad and Tobago,"Oxford/AstraZeneca, Pfizer/BioNTech Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
+2021-09-18,557693,462338.0,1020031.0,Trinidad and Tobago,"Oxford/AstraZeneca, Pfizer/BioNTech Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
+2021-09-19,558486,463504.0,1021990.0,Trinidad and Tobago,"Oxford/AstraZeneca, Pfizer/BioNTech Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
+2021-09-20,558811,464129.0,1022940.0,Trinidad and Tobago,"Oxford/AstraZeneca, Pfizer/BioNTech Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
+2021-09-21,560725,467790.0,1028515.0,Trinidad and Tobago,"Oxford/AstraZeneca, Pfizer/BioNTech Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
+2021-09-22,562582,470075.0,1032657.0,Trinidad and Tobago,"Oxford/AstraZeneca, Pfizer/BioNTech Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
+2021-09-23,564315,473097.0,1037412.0,Trinidad and Tobago,"Oxford/AstraZeneca, Pfizer/BioNTech Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/
+2021-09-24,565940,475896.0,1041836.0,Trinidad and Tobago,"Oxford/AstraZeneca, Pfizer/BioNTech Sinopharm/Beijing",https://experience.arcgis.com/experience/59226cacd2b441c7a939dca13f832112/

--- a/scripts/src/cowidev/vax/batch/trinidad_and_tobago.py
+++ b/scripts/src/cowidev/vax/batch/trinidad_and_tobago.py
@@ -40,7 +40,7 @@ def enrich_location(df: pd.DataFrame) -> pd.DataFrame:
 
 
 def enrich_vaccine_name(df: pd.DataFrame) -> pd.DataFrame:
-    return df.assign(vaccine="Oxford/AstraZeneca, Sinopharm/Beijing")
+    return df.assign(vaccine="Oxford/AstraZeneca, Pfizer/BioNTech Sinopharm/Beijing")
 
 
 def enrich_source(df: pd.DataFrame, source: str) -> pd.DataFrame:


### PR DESCRIPTION
Update Trinidad and Tobago

Source : https://tt.usembassy.gov/united-states-donates-305370-pfizer-covid-19-vaccine-doses-to-trinidad-and-tobago/