### PR TITLE
fix: subnational zip file gets created properly

### DIFF
--- a/scripts/scripts/jhu.py
+++ b/scripts/scripts/jhu.py
@@ -287,7 +287,8 @@ def create_subnational():
         ]
     ]
     df = df[df.total_cases > 0]
-    df.to_csv(os.path.join(OUTPUT_PATH, "subnational_cases_deaths.zip"), index=False, compression="zip")
+    df.to_csv(os.path.join(OUTPUT_PATH, "subnational_cases_deaths.zip"), index=False,
+              compression={"method": "zip", "archive_name": "subnational_cases_deaths.csv"})
 
 
 def main(skip_download=False):


### PR DESCRIPTION
Hello 👋 

So as I just found out, the `subnational_cases_deaths.zip` file was _mostly_ broken.
The file structure _inside_ the zip file looks as follows: 
```
> unzip -l subnational_cases_deaths.zip

Archive:  subnational_cases_deaths.zip
  Length      Date    Time    Name
---------  ---------- -----   ----
132092992  2021-11-14 08:04   /home/owid/covid-19-data/scripts/scripts/../../public/data/jhu/subnational_cases_deaths.zip
---------                     -------
132092992                     1 file
```

So, the zip file contains _another_ zip file. It's lying! That zip file is, in fact, the `.csv` file created by pandas. But due to a [bug in pandas](https://github.com/pandas-dev/pandas/issues/39465), it would name the zip file contents the same as the filename passed to `to_csv`.

With the contents being the way they are, Windows couldn't even read the zip file. It just reported that it was empty.

This little fix fixes that issue, and creates the csv file inside the zip file as intended.

---

PS: The file is almost 16MB at the moment, making it one of the largest regulary-updated binary files in the repo - blowing up the repo and git by a lot.
Seeing that it _almost_[^1] couldn't be used for the last few months at least, this could also be a good point in time to deprecate it :)

[^1]: It could be properly read using `zless`, `zmore`, `zcat` and the like.