### PR TITLE
Update Armenia.csv

### DIFF
--- a/public/data/vaccinations/country_data/Armenia.csv
+++ b/public/data/vaccinations/country_data/Armenia.csv
@@ -24,4 +24,6 @@ Armenia,2021-10-11,"Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac, Sputnik V",h
 Armenia,2021-10-17,"Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac, Sputnik V",https://worldhealthorg.shinyapps.io/EURO_COVID-19_vaccine_monitor/,620698,434617,186081,
 Armenia,2021-10-24,"Moderna, Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac, Sputnik V",https://covid19.who.int/,709345,497971,211374,
 Armenia,2021-10-31,"Moderna, Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac, Sputnik V",https://covid19.who.int/,831856,579360,252496,
-Armenia,2021-11-14,"Moderna, Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac, Sputnik V",https://covid19.who.int/,923530,645035,278495,
+Armenia,2021-11-07,"Moderna, Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac, Sputnik V",https://www.moh.am/#1/4517,890797,613849,276948,
+Armenia,2021-11-14,"Moderna, Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac, Sputnik V",https://www.moh.am/#1/4376,1004493,682188,322305,
+Armenia,2021-11-21,"Moderna, Oxford/AstraZeneca, Sinopharm/Beijing, Sinovac, Sputnik V",https://www.moh.am/#1/4574,1110891,738887,372004,


### PR DESCRIPTION
Added information from Armenia's Ministry of Health (MoH) announcements.

Armenia's vaccination data was previously automated using the facebook_scraper python package, but the automation has stopped working starting a few weeks ago since the announcement format has changed and also fetching the MoH page's posts doesn't seem to work anymore. Maybe facebook_scraper has somehow been blocked for that page.