### PR TITLE
Vietnam, this number data isn't report for 6 days

### DIFF
--- a/public/data/vaccinations/locations.csv
+++ b/public/data/vaccinations/locations.csv
@@ -216,7 +216,7 @@ Uruguay,URY,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinovac",2021-11-27,Ministry o
 Uzbekistan,UZB,"Moderna, Oxford/AstraZeneca, Sputnik V, ZF2001",2021-11-26,Government of Uzbekistan,https://coronavirus.uz/uz/lists
 Vanuatu,VUT,Oxford/AstraZeneca,2021-11-22,SPC Public Health Division,https://stats.pacificdata.org/vis?tm=covid&pg=0&df[ds]=SPC2&df[id]=DF_COVID_VACCINATION&df[ag]=SPC&df[vs]=1.0
 Venezuela,VEN,"Abdala, Sinopharm/Beijing, Sinopharm/Wuhan, Sputnik V",2021-11-05,Pan American Health Organization,https://ais.paho.org/imm/IM_DosisAdmin-Vacunacion.asp
-Vietnam,VNM,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech, Sinopharm/Beijing, Sputnik V",2021-11-23,Government of Vietnam,https://moh.gov.vn:443/tin-tong-hop/-/asset_publisher/k206Q9qkZOqn/content/ngay-24-11-co-11-811-ca-covid-19-gan-26-000-benh-nhan-khoi-gap-2-5-lan-so-mac-moi
+Vietnam,VNM,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech, Sinopharm/Beijing, Sputnik V",2021-11-23,Government of Vietnam,https://moh.gov.vn/tin-tong-hop/-/asset_publisher/k206Q9qkZOqn/content/ngay-28-11-co-12-936-ca-covid-19-binh-phuoc-ben-tre-va-hai-phong-tang-so-mac
 Wales,OWID_WLS,"Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",2021-11-26,Government of the United Kingdom,https://coronavirus.data.gov.uk/details/vaccinations
 Wallis and Futuna,WLF,Moderna,2021-11-22,SPC Public Health Division,https://stats.pacificdata.org/vis?tm=covid&pg=0&df[ds]=SPC2&df[id]=DF_COVID_VACCINATION&df[ag]=SPC&df[vs]=1.0
 Yemen,YEM,"Johnson&Johnson, Oxford/AstraZeneca, Sinovac",2021-11-21,World Health Organization,https://covid19.who.int/


### PR DESCRIPTION
Hi @edomt and @lucasrodes 

I noticed that the data from Vietnam for the number of tests performed were being obtained incrementally from an HTML page.

I propose new data which was updated in last day.

The data is on the Ministry of Health portal, which is an official web of the Ministry of Health of Vietnam.
But, the domain of this data is not hosted in moh.gov.vn to circumvent access restrictions from abroad.

Check if the proposal is correct.
Make sure it will be noticed it.

I hope it is useful.
Regards
Phuclygia