### PR TITLE
fix(taiwan): the extraction of 2021-12-03

### DIFF
--- a/scripts/output/vaccinations/main_data/Taiwan.csv
+++ b/scripts/output/vaccinations/main_data/Taiwan.csv
@@ -210,3 +210,4 @@ Taiwan,2021-11-29,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https:
 Taiwan,2021-11-30,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,31546833,18246772,13300061
 Taiwan,2021-12-01,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,31810156,18272135,13538021
 Taiwan,2021-12-02,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,31998733,18281218,13717515
+Taiwan,2021-12-03,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,32273067,18290428,13982639

--- a/scripts/src/cowidev/vax/incremental/taiwan.py
+++ b/scripts/src/cowidev/vax/incremental/taiwan.py
@@ -17,7 +17,7 @@ class Taiwan:
     def __init__(self):
         self.source_url = "https://www.cdc.gov.tw"
         self.location = "Taiwan"
-        self.columns_accepted = {"廠牌", "劑次", "12/2接種劑數", "累計至 12/2接種劑數"}
+        self.columns_accepted = {"廠牌", "劑次", "12/3接種劑數", "累計至 12/3接種劑數"}
         self.vaccines_mapping = {
             "AstraZeneca": "Oxford/AstraZeneca",
             "高端": "Medigen",
@@ -55,9 +55,10 @@ class Taiwan:
         cols_wrong = df.columns.difference(self.columns_accepted)
         if cols_wrong.any():
             raise ValueError(f"There are some unknown columns: {cols_wrong}")
+
         # Fix index
-        index_ = df["廠牌"].iloc[:-1].shift().fillna(method="bfill")
-        df["廠牌"].iloc[:-1] = index_
+        index_ = df["廠牌"].shift().fillna(method="bfill")
+        df["廠牌"] = index_
         df = df.set_index(["廠牌", "劑次"])
         # Drop NaNs
         df = df.dropna()
@@ -101,7 +102,7 @@ class Taiwan:
         #     num_dose1 = clean_count(num1.split(" ")[-1])
         #     num_dose2 = clean_count(num2.split(" ")[-1])
 
-        if df.shape != (11, 2):
+        if df.shape != (13, 2):
             raise ValueError(f"Table 1: format has changed!")
 
         num_dose1 = clean_count(df.loc["總計", "第 1劑"]["total"])


### PR DESCRIPTION
Extra rows labled with "追加劑" are added to the table to show the
stats of 3rd doses -- but only under some of brands. I'm guessing we
will have to re-visit this parser soon.