### PR TITLE
fix(taiwan): update the sanity checks according to new format.

### DIFF
--- a/scripts/output/vaccinations/main_data/Taiwan.csv
+++ b/scripts/output/vaccinations/main_data/Taiwan.csv
@@ -212,3 +212,4 @@ Taiwan,2021-12-01,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https:
 Taiwan,2021-12-02,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,31998733,18281218,13717515
 Taiwan,2021-12-03,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,32273067,18290428,13982639
 Taiwan,2021-12-05,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,32471621,18302323,14169298
+Taiwan,2021-12-06,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,32680126,18317806,14362320

--- a/scripts/src/cowidev/vax/incremental/taiwan.py
+++ b/scripts/src/cowidev/vax/incremental/taiwan.py
@@ -58,8 +58,8 @@ class Taiwan:
             and cols[0] == "廠牌"
             and cols[1] == "劑次"
             and cols[2].endswith("接種人次")
-            and re.match(r"\d+\/\d+\-\d+\/\d+接種人次", cols[2])
-            and re.match(r"累計至 \d+\/\d+接種人次", cols[3])
+            and re.match(r"(\d+\/\d+ *\- *)?\d+\/\d+ *接種人次", cols[2])
+            and re.match(r"累計至 *\d+\/\d+ *接種人次", cols[3])
         ):
             raise ValueError(f"There are some unknown columns: {cols}")
 
@@ -109,7 +109,7 @@ class Taiwan:
         #     num_dose1 = clean_count(num1.split(" ")[-1])
         #     num_dose2 = clean_count(num2.split(" ")[-1])
 
-        if df.shape != (13, 2):
+        if df.shape != (15, 2):
             raise ValueError(f"Table 1: format has changed!")
 
         num_dose1 = clean_count(df.loc["總計", "第 1劑"]["total"])


### PR DESCRIPTION
The sanity checks of column names are relaxed a little bit to account
for whitespaces conventionally put in between digits and Chinese
characters.

Also, the number of rows has increased due to the newly added stats
for booster shots ("追加劑" in the table.)