### PR TITLE
Taiwan csv: include totoal booster

### DIFF
--- a/scripts/output/vaccinations/main_data/Taiwan.csv
+++ b/scripts/output/vaccinations/main_data/Taiwan.csv
@@ -209,8 +209,8 @@ Taiwan,2021-11-28,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https:
 Taiwan,2021-11-29,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,31255998,18216396,13039602,
 Taiwan,2021-11-30,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,31546833,18246772,13300061,
 Taiwan,2021-12-01,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,31810156,18272135,13538021,
-Taiwan,2021-12-02,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,31998733,18281218,13717515,
-Taiwan,2021-12-03,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,32273067,18290428,13982639,
-Taiwan,2021-12-05,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,32471621,18302323,14169298,
-Taiwan,2021-12-06,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,32680126,18317806,14362320,
+Taiwan,2021-12-02,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,31998733,18281218,13717515,63
+Taiwan,2021-12-03,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,32273067,18290428,13982639,2222
+Taiwan,2021-12-05,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,32471621,18302323,14169298,4974
+Taiwan,2021-12-06,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,32680126,18317806,14362320,9093
 Taiwan,2021-12-07,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,32885283,18338424,14546859,13118

--- a/scripts/output/vaccinations/main_data/Taiwan.csv
+++ b/scripts/output/vaccinations/main_data/Taiwan.csv
@@ -1,215 +1,216 @@
-location,date,vaccine,source_url,total_vaccinations,people_vaccinated,people_fully_vaccinated
-Taiwan,2021-03-21,Oxford/AstraZeneca,https://www.cdc.gov.tw/Uploads/ba3841c3-3755-423d-a204-bde17d46db38.pdf,0,0,0
-Taiwan,2021-03-22,Oxford/AstraZeneca,https://www.cdc.gov.tw/Uploads/ba3841c3-3755-423d-a204-bde17d46db38.pdf,1578,1578,0
-Taiwan,2021-03-23,Oxford/AstraZeneca,https://www.cdc.gov.tw/Uploads/a0398a90-4dff-4e08-a07a-f920ada55c60.pdf,3218,3218,0
-Taiwan,2021-03-24,Oxford/AstraZeneca,https://www.cdc.gov.tw/Uploads/86cf5eb3-4c75-406e-970a-d01656fd0f6c.pdf,5169,5169,0
-Taiwan,2021-03-25,Oxford/AstraZeneca,https://www.cdc.gov.tw/File/Get/OPUECKp6TJZeKcN_TqrYXw,7053,7053,0
-Taiwan,2021-03-26,Oxford/AstraZeneca,https://www.cdc.gov.tw/File/Get/hq1bYGuBSaivZDrhzTvIhwt,9232,9232,0
-Taiwan,2021-03-27,Oxford/AstraZeneca,https://www.cdc.gov.tw/File/Get/Sad4z5QXaWBfLtZNk5DhMQ,9377,9377,0
-Taiwan,2021-03-28,Oxford/AstraZeneca,https://www.cdc.gov.tw/File/Get/h1zrpULPsrECHmJXHeRrwg,9412,9412,0
-Taiwan,2021-03-29,Oxford/AstraZeneca,https://www.cdc.gov.tw/File/Get/FL-qq_yyvAEnjdiXZW8oZg,10891,10891,0
-Taiwan,2021-03-30,Oxford/AstraZeneca,https://www.cdc.gov.tw/File/Get/XKCGkbm_Y-PTUzt6I8uAwQ,12648,12648,0
-Taiwan,2021-03-31,Oxford/AstraZeneca,https://www.cdc.gov.tw/File/Get/XKCGkbm_Y-PTUzt6I8uAwQ,14400,14400,0
-Taiwan,2021-04-01,Oxford/AstraZeneca,https://www.cdc.gov.tw/File/Get/ZEgt5pazQMtu1a-T9wLoJA,16450,16450,0
-Taiwan,2021-04-02,Oxford/AstraZeneca,https://www.cdc.gov.tw/Uploads/c9f7dca2-96fd-4238-bd39-46318cd0e353.pdf,17056,17056,0
-Taiwan,2021-04-03,Oxford/AstraZeneca,https://www.cdc.gov.tw/Uploads/2b8b62e6-8dc4-45c4-8402-d336a3459d6b.pdf,17078,17078,0
-Taiwan,2021-04-04,Oxford/AstraZeneca,https://www.cdc.gov.tw/Uploads/0133ff8f-71a6-4e75-b81a-799f4e5d1035.pdf,17078,17078,0
-Taiwan,2021-04-05,Oxford/AstraZeneca,https://www.cdc.gov.tw/Uploads/0133ff8f-71a6-4e75-b81a-799f4e5d1035.pdf,17245,17245,0
-Taiwan,2021-04-06,Oxford/AstraZeneca,https://www.cdc.gov.tw/File/Get/dvIhH6wnng17XsYuOy7ylw,18657,18657,0
-Taiwan,2021-04-07,Oxford/AstraZeneca,https://www.cdc.gov.tw/Uploads/e72faf47-1ff6-421e-a7cf-ec6d1cc51497.pdf,20075,20075,0
-Taiwan,2021-04-08,Oxford/AstraZeneca,https://www.cdc.gov.tw/File/Get/z3T5VogvTEztaRGM5J0-nA,21873,21873,0
-Taiwan,2021-04-09,Oxford/AstraZeneca,https://www.cdc.gov.tw/File/Get/z3T5VogvTEztaRGM5J0-nA,24450,24450,0
-Taiwan,2021-04-10,Oxford/AstraZeneca,https://www.cdc.gov.tw/File/Get/4YWRnM838BMcblRbg_64RQ,24658,24658,0
-Taiwan,2021-04-11,Oxford/AstraZeneca,https://www.cdc.gov.tw/File/Get/zbePMejDRTLdHfFTDDZYsA,24701,24701,0
-Taiwan,2021-04-12,Oxford/AstraZeneca,https://www.cdc.gov.tw/File/Get/zbePMejDRTLdHfFTDDZYsA,25882,25882,0
-Taiwan,2021-04-13,Oxford/AstraZeneca,https://www.cdc.gov.tw/File/Get/rhp4SvcDhmh2bEOWduNrXg,27113,27113,0
-Taiwan,2021-04-14,Oxford/AstraZeneca,https://www.cdc.gov.tw/Uploads/6dafd877-60c2-45c3-90a1-8853a82c23c4.pdf,28497,28497,0
-Taiwan,2021-04-15,Oxford/AstraZeneca,https://www.cdc.gov.tw/Uploads/6dafd877-60c2-45c3-90a1-8853a82c23c4.pdf,30039,30039,0
-Taiwan,2021-04-16,Oxford/AstraZeneca,https://www.cdc.gov.tw/Uploads/77c3c313-2ebe-4f1b-b5c3-c18fad0781c2.pdf,32389,32389,0
-Taiwan,2021-04-17,Oxford/AstraZeneca,https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,32450,32450,0
-Taiwan,2021-04-20,Oxford/AstraZeneca,https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,34197,34197,0
-Taiwan,2021-04-21,Oxford/AstraZeneca,https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,36731,36731,0
-Taiwan,2021-04-22,Oxford/AstraZeneca,https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,39221,39221,0
-Taiwan,2021-04-23,Oxford/AstraZeneca,https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,42523,42523,0
-Taiwan,2021-04-24,Oxford/AstraZeneca,https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,42672,42672,0
-Taiwan,2021-04-26,Oxford/AstraZeneca,https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,45387,45387,0
-Taiwan,2021-04-27,Oxford/AstraZeneca,https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,48180,48180,0
-Taiwan,2021-04-28,Oxford/AstraZeneca,https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,50833,50833,0
-Taiwan,2021-04-29,Oxford/AstraZeneca,https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,54189,54189,0
-Taiwan,2021-04-30,Oxford/AstraZeneca,https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,57884,57884,0
-Taiwan,2021-05-02,Oxford/AstraZeneca,https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,58252,58252,0
-Taiwan,2021-05-03,Oxford/AstraZeneca,https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,62437,62437,0
-Taiwan,2021-05-04,Oxford/AstraZeneca,https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,67931,67931,0
-Taiwan,2021-05-05,Oxford/AstraZeneca,https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,73988,73988,0
-Taiwan,2021-05-06,Oxford/AstraZeneca,https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,80861,80861,0
-Taiwan,2021-05-07,Oxford/AstraZeneca,https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,91002,91002,0
-Taiwan,2021-05-09,Oxford/AstraZeneca,https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,92049,92049,0
-Taiwan,2021-05-11,Oxford/AstraZeneca,https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,112543,112543,0
-Taiwan,2021-05-12,Oxford/AstraZeneca,https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,129669,129669,0
-Taiwan,2021-05-13,Oxford/AstraZeneca,https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,151997,151997,0
-Taiwan,2021-05-14,Oxford/AstraZeneca,https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,186149,186149,0
-Taiwan,2021-05-16,Oxford/AstraZeneca,https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,194678,194678,0
-Taiwan,2021-05-17,Oxford/AstraZeneca,https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,220352,220352,0
-Taiwan,2021-05-18,Oxford/AstraZeneca,https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,245008,245008,0
-Taiwan,2021-05-19,Oxford/AstraZeneca,https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,264589,264589,0
-Taiwan,2021-05-20,Oxford/AstraZeneca,https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,281647,281647,0
-Taiwan,2021-05-21,Oxford/AstraZeneca,https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,299844,299844,0
-Taiwan,2021-05-23,Oxford/AstraZeneca,https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,302698,302698,0
-Taiwan,2021-05-24,Oxford/AstraZeneca,https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,311678,311678,0
-Taiwan,2021-05-25,Oxford/AstraZeneca,https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,319665,319665,0
-Taiwan,2021-06-02,Oxford/AstraZeneca,https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,562029,562029,0
-Taiwan,2021-06-03,Oxford/AstraZeneca,https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,624132,624132,0
-Taiwan,2021-06-04,Oxford/AstraZeneca,https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,678418,678418,0
-Taiwan,2021-06-06,Oxford/AstraZeneca,https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,699187,699187,0
-Taiwan,2021-06-07,Oxford/AstraZeneca,https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,724819,724819,0
-Taiwan,2021-06-08,Oxford/AstraZeneca,https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,743578,743578,0
-Taiwan,2021-06-09,Oxford/AstraZeneca,https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,759746,759746,0
-Taiwan,2021-06-10,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,782300,782300,0
-Taiwan,2021-06-11,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,799129,799129,0
-Taiwan,2021-06-14,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,855125,855125,0
-Taiwan,2021-06-15,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,1009160,985084,24076
-Taiwan,2021-06-16,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,1178104,,
-Taiwan,2021-06-17,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,1321839,,
-Taiwan,2021-06-18,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,1429514,,
-Taiwan,2021-06-20,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,1541732,,
-Taiwan,2021-06-21,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,1616384,1587581,28803
-Taiwan,2021-06-22,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,1681936,1652232,29704
-Taiwan,2021-06-23,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,1746130,1714268,31862
-Taiwan,2021-06-24,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,1835225,1801743,33482
-Taiwan,2021-06-25,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,1905474,1869105,36369
-Taiwan,2021-06-27,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,1926973,1890292,36681
-Taiwan,2021-06-28,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,1964592,1926572,38020
-Taiwan,2021-06-29,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,2002677,1962990,39687
-Taiwan,2021-06-30,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,2043218,2001418,41800
-Taiwan,2021-07-01,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,2087587,2044241,43346
-Taiwan,2021-07-02,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,2278338,2232145,46193
-Taiwan,2021-07-04,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,2518860,2472399,46461
-Taiwan,2021-07-05,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,2628789,2581047,47742
-Taiwan,2021-07-06,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,2740540,2691066,49474
-Taiwan,2021-07-07,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,2899997,2847653,52344
-Taiwan,2021-07-08,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,3121081,3060361,60720
-Taiwan,2021-07-09,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,3357000,3284679,72321
-Taiwan,2021-07-11,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,3565840,3492257,73583
-Taiwan,2021-07-12,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,3821539,3742680,78859
-Taiwan,2021-07-13,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,4084061,3998233,85828
-Taiwan,2021-07-14,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,4337272,4242075,95197
-Taiwan,2021-07-15,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,4603639,4496176,107463
-Taiwan,2021-07-16,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,4916652,4790949,125703
-Taiwan,2021-07-18,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,5194107,5064007,130100
-Taiwan,2021-07-19,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,5419988,5279558,140430
-Taiwan,2021-07-20,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,5674553,5520060,154493
-Taiwan,2021-07-21,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,5894500,5718272,176228
-Taiwan,2021-07-22,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,6059596,5858787,200809
-Taiwan,2021-07-23,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,6347065,6117598,229467
-Taiwan,2021-07-25,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,6674129,6433287,240842
-Taiwan,2021-07-26,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,7013130,6751025,262105
-Taiwan,2021-07-27,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,7318286,7030253,288033
-Taiwan,2021-07-28,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,7588692,7273091,315601
-Taiwan,2021-07-29,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,7826972,7484172,342800
-Taiwan,2021-07-30,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,8088871,7707830,381041
-Taiwan,2021-08-01,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,8270213,7881726,388487
-Taiwan,2021-08-02,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,8405085,8001300,403785
-Taiwan,2021-08-03,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,8501137,8083073,418064
-Taiwan,2021-08-04,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,8607387,8170117,437270
-Taiwan,2021-08-05,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,8875048,8418179,456869
-Taiwan,2021-08-06,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,9154501,8661701,492800
-Taiwan,2021-08-08,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,9180297,8679320,500977
-Taiwan,2021-08-09,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,9228263,8709234,519029
-Taiwan,2021-08-10,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,9265758,8725490,540268
-Taiwan,2021-08-11,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,9433236,8867289,565947
-Taiwan,2021-08-12,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,9602785,9006569,596216
-Taiwan,2021-08-13,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,9749241,9100495,648746
-Taiwan,2021-08-15,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,9824837,9162953,661884
-Taiwan,2021-08-16,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,9887295,9203556,683739
-Taiwan,2021-08-17,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,9951034,9247088,703946
-Taiwan,2021-08-18,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,9985997,9260988,725009
-Taiwan,2021-08-19,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,10014566,9269265,745301
-Taiwan,2021-08-20,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,10057641,9285878,771763
-Taiwan,2021-08-22,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,10067762,9290591,777171
-Taiwan,2021-08-23,"Medigen, Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,10246977,9463223,783754
-Taiwan,2021-08-24,"Medigen, Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,10404722,9602065,802657
-Taiwan,2021-08-25,"Medigen, Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,10497159,9678947,818212
-Taiwan,2021-08-26,"Medigen, Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,10586017,9742912,843105
-Taiwan,2021-08-27,"Medigen, Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,10779334,9908979,870355
-Taiwan,2021-08-29,"Medigen, Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,10886165,10005255,880910
-Taiwan,2021-08-30,"Medigen, Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,10928720,10028069,900651
-Taiwan,2021-08-31,"Medigen, Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,10958966,10038004,920962
-Taiwan,2021-09-01,"Medigen, Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,10982471,10046132,936339
-Taiwan,2021-09-02,"Medigen, Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,11004240,10051070,953170
-Taiwan,2021-09-03,"Medigen, Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,11243600,10272559,971041
-Taiwan,2021-09-05,"Medigen, Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,11380968,10399097,981871
-Taiwan,2021-09-06,"Medigen, Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,11456359,10468680,987679
-Taiwan,2021-09-07,"Medigen, Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,11548606,10552459,996147
-Taiwan,2021-09-08,"Medigen, Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,11660683,10652241,1008442
-Taiwan,2021-09-09,"Medigen, Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,11961678,10941158,1020520
-Taiwan,2021-09-10,"Medigen, Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,12301555,11263210,1038345
-Taiwan,2021-09-12,"Medigen, Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,12463192,11416544,1046648
-Taiwan,2021-09-13,"Medigen, Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,12488096,11433445,1054651
-Taiwan,2021-09-14,"Medigen, Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,12504662,11442116,1062546
-Taiwan,2021-09-15,"Medigen, Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,12708428,11483332,1225096
-Taiwan,2021-09-16,"Medigen, Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,12938098,11536036,1402062
-Taiwan,2021-09-17,"Medigen, Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,13171843,11593038,1578805
-Taiwan,2021-09-21,"Medigen, Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,13405357,11689760,1715597
-Taiwan,2021-09-22,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,13589767,11763739,1826028
-Taiwan,2021-09-23,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,13856466,11912534,1943932
-Taiwan,2021-09-24,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,14142461,12075243,2067218
-Taiwan,2021-09-26,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,14430076,12278191,2151885
-Taiwan,2021-09-27,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,14763330,12551676,2211654
-Taiwan,2021-09-28,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,15091281,12812763,2278518
-Taiwan,2021-09-29,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,15441421,13065648,2375773
-Taiwan,2021-09-30,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,15880889,13243149,2637740
-Taiwan,2021-10-01,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,16277198,13424778,2852420
-Taiwan,2021-10-03,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,16558959,13477691,3081268
-Taiwan,2021-10-04,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,16820590,13524914,3295676
-Taiwan,2021-10-05,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,17021317,13577317,3444000
-Taiwan,2021-10-06,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,17218445,13616764,3601681
-Taiwan,2021-10-07,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,17541591,13666555,3875036
-Taiwan,2021-10-08,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,17887465,13711680,4175785
-Taiwan,2021-10-11,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,18240856,13759882,4480974
-Taiwan,2021-10-12,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,18497356,13797381,4699975
-Taiwan,2021-10-13,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,18766730,13980025,4786705
-Taiwan,2021-10-14,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,19026022,14152139,4873883
-Taiwan,2021-10-15,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,19435019,14395967,5039052
-Taiwan,2021-10-17,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,19825683,14620207,5205476
-Taiwan,2021-10-18,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,20204959,14877506,5327453
-Taiwan,2021-10-19,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,20541421,15063365,5478056
-Taiwan,2021-10-20,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,20920995,15229608,5691387
-Taiwan,2021-10-21,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,21264787,15353595,5911192
-Taiwan,2021-10-22,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,21717020,15555520,6161500
-Taiwan,2021-10-24,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,22283271,15865789,6417482
-Taiwan,2021-10-25,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,22783694,16105123,6678571
-Taiwan,2021-10-26,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,23217629,16281201,6936428
-Taiwan,2021-10-27,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,23637150,16404793,7232357
-Taiwan,2021-10-28,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,24048734,16656545,7392189
-Taiwan,2021-10-29,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,24481074,16951012,7530062
-Taiwan,2021-10-31,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,24870150,17214718,7655432
-Taiwan,2021-11-01,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,25182013,17286000,7896013
-Taiwan,2021-11-02,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,25486269,17331396,8154873
-Taiwan,2021-11-03,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,25778064,17384932,8393132
-Taiwan,2021-11-04,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,25851240,17399450,8451790
-Taiwan,2021-11-05,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,26080250,17436784,8643466
-Taiwan,2021-11-07,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,26281921,17484037,8797884
-Taiwan,2021-11-08,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,26542566,17557602,8984964
-Taiwan,2021-11-09,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,26768810,17622921,9145889
-Taiwan,2021-11-10,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,27004426,17689522,9314904
-Taiwan,2021-11-11,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,27210265,17744846,9465419
-Taiwan,2021-11-12,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,27479599,17808765,9670834
-Taiwan,2021-11-14,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,27689479,17851199,9838280
-Taiwan,2021-11-15,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,27927621,17891819,10035802
-Taiwan,2021-11-16,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,28161546,17931470,10230076
-Taiwan,2021-11-17,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,28403884,17961336,10442548
-Taiwan,2021-11-18,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,28679327,17981769,10697558
-Taiwan,2021-11-19,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,28986957,18016118,10970839
-Taiwan,2021-11-22,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,29515207,18064753,11450454
-Taiwan,2021-11-23,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,29749086,18087393,11661693
-Taiwan,2021-11-24,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,29932419,18109173,11823246
-Taiwan,2021-11-25,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,30254219,18136444,12117775
-Taiwan,2021-11-26,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,30648405,18168092,12480313
-Taiwan,2021-11-28,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,30965234,18193419,12771815
-Taiwan,2021-11-29,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,31255998,18216396,13039602
-Taiwan,2021-11-30,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,31546833,18246772,13300061
-Taiwan,2021-12-01,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,31810156,18272135,13538021
-Taiwan,2021-12-02,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,31998733,18281218,13717515
-Taiwan,2021-12-03,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,32273067,18290428,13982639
-Taiwan,2021-12-05,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,32471621,18302323,14169298
-Taiwan,2021-12-06,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,32680126,18317806,14362320
+location,date,vaccine,source_url,total_vaccinations,people_vaccinated,people_fully_vaccinated,total_boosters
+Taiwan,2021-03-21,Oxford/AstraZeneca,https://www.cdc.gov.tw/Uploads/ba3841c3-3755-423d-a204-bde17d46db38.pdf,0,0,0,
+Taiwan,2021-03-22,Oxford/AstraZeneca,https://www.cdc.gov.tw/Uploads/ba3841c3-3755-423d-a204-bde17d46db38.pdf,1578,1578,0,
+Taiwan,2021-03-23,Oxford/AstraZeneca,https://www.cdc.gov.tw/Uploads/a0398a90-4dff-4e08-a07a-f920ada55c60.pdf,3218,3218,0,
+Taiwan,2021-03-24,Oxford/AstraZeneca,https://www.cdc.gov.tw/Uploads/86cf5eb3-4c75-406e-970a-d01656fd0f6c.pdf,5169,5169,0,
+Taiwan,2021-03-25,Oxford/AstraZeneca,https://www.cdc.gov.tw/File/Get/OPUECKp6TJZeKcN_TqrYXw,7053,7053,0,
+Taiwan,2021-03-26,Oxford/AstraZeneca,https://www.cdc.gov.tw/File/Get/hq1bYGuBSaivZDrhzTvIhwt,9232,9232,0,
+Taiwan,2021-03-27,Oxford/AstraZeneca,https://www.cdc.gov.tw/File/Get/Sad4z5QXaWBfLtZNk5DhMQ,9377,9377,0,
+Taiwan,2021-03-28,Oxford/AstraZeneca,https://www.cdc.gov.tw/File/Get/h1zrpULPsrECHmJXHeRrwg,9412,9412,0,
+Taiwan,2021-03-29,Oxford/AstraZeneca,https://www.cdc.gov.tw/File/Get/FL-qq_yyvAEnjdiXZW8oZg,10891,10891,0,
+Taiwan,2021-03-30,Oxford/AstraZeneca,https://www.cdc.gov.tw/File/Get/XKCGkbm_Y-PTUzt6I8uAwQ,12648,12648,0,
+Taiwan,2021-03-31,Oxford/AstraZeneca,https://www.cdc.gov.tw/File/Get/XKCGkbm_Y-PTUzt6I8uAwQ,14400,14400,0,
+Taiwan,2021-04-01,Oxford/AstraZeneca,https://www.cdc.gov.tw/File/Get/ZEgt5pazQMtu1a-T9wLoJA,16450,16450,0,
+Taiwan,2021-04-02,Oxford/AstraZeneca,https://www.cdc.gov.tw/Uploads/c9f7dca2-96fd-4238-bd39-46318cd0e353.pdf,17056,17056,0,
+Taiwan,2021-04-03,Oxford/AstraZeneca,https://www.cdc.gov.tw/Uploads/2b8b62e6-8dc4-45c4-8402-d336a3459d6b.pdf,17078,17078,0,
+Taiwan,2021-04-04,Oxford/AstraZeneca,https://www.cdc.gov.tw/Uploads/0133ff8f-71a6-4e75-b81a-799f4e5d1035.pdf,17078,17078,0,
+Taiwan,2021-04-05,Oxford/AstraZeneca,https://www.cdc.gov.tw/Uploads/0133ff8f-71a6-4e75-b81a-799f4e5d1035.pdf,17245,17245,0,
+Taiwan,2021-04-06,Oxford/AstraZeneca,https://www.cdc.gov.tw/File/Get/dvIhH6wnng17XsYuOy7ylw,18657,18657,0,
+Taiwan,2021-04-07,Oxford/AstraZeneca,https://www.cdc.gov.tw/Uploads/e72faf47-1ff6-421e-a7cf-ec6d1cc51497.pdf,20075,20075,0,
+Taiwan,2021-04-08,Oxford/AstraZeneca,https://www.cdc.gov.tw/File/Get/z3T5VogvTEztaRGM5J0-nA,21873,21873,0,
+Taiwan,2021-04-09,Oxford/AstraZeneca,https://www.cdc.gov.tw/File/Get/z3T5VogvTEztaRGM5J0-nA,24450,24450,0,
+Taiwan,2021-04-10,Oxford/AstraZeneca,https://www.cdc.gov.tw/File/Get/4YWRnM838BMcblRbg_64RQ,24658,24658,0,
+Taiwan,2021-04-11,Oxford/AstraZeneca,https://www.cdc.gov.tw/File/Get/zbePMejDRTLdHfFTDDZYsA,24701,24701,0,
+Taiwan,2021-04-12,Oxford/AstraZeneca,https://www.cdc.gov.tw/File/Get/zbePMejDRTLdHfFTDDZYsA,25882,25882,0,
+Taiwan,2021-04-13,Oxford/AstraZeneca,https://www.cdc.gov.tw/File/Get/rhp4SvcDhmh2bEOWduNrXg,27113,27113,0,
+Taiwan,2021-04-14,Oxford/AstraZeneca,https://www.cdc.gov.tw/Uploads/6dafd877-60c2-45c3-90a1-8853a82c23c4.pdf,28497,28497,0,
+Taiwan,2021-04-15,Oxford/AstraZeneca,https://www.cdc.gov.tw/Uploads/6dafd877-60c2-45c3-90a1-8853a82c23c4.pdf,30039,30039,0,
+Taiwan,2021-04-16,Oxford/AstraZeneca,https://www.cdc.gov.tw/Uploads/77c3c313-2ebe-4f1b-b5c3-c18fad0781c2.pdf,32389,32389,0,
+Taiwan,2021-04-17,Oxford/AstraZeneca,https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,32450,32450,0,
+Taiwan,2021-04-20,Oxford/AstraZeneca,https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,34197,34197,0,
+Taiwan,2021-04-21,Oxford/AstraZeneca,https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,36731,36731,0,
+Taiwan,2021-04-22,Oxford/AstraZeneca,https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,39221,39221,0,
+Taiwan,2021-04-23,Oxford/AstraZeneca,https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,42523,42523,0,
+Taiwan,2021-04-24,Oxford/AstraZeneca,https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,42672,42672,0,
+Taiwan,2021-04-26,Oxford/AstraZeneca,https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,45387,45387,0,
+Taiwan,2021-04-27,Oxford/AstraZeneca,https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,48180,48180,0,
+Taiwan,2021-04-28,Oxford/AstraZeneca,https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,50833,50833,0,
+Taiwan,2021-04-29,Oxford/AstraZeneca,https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,54189,54189,0,
+Taiwan,2021-04-30,Oxford/AstraZeneca,https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,57884,57884,0,
+Taiwan,2021-05-02,Oxford/AstraZeneca,https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,58252,58252,0,
+Taiwan,2021-05-03,Oxford/AstraZeneca,https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,62437,62437,0,
+Taiwan,2021-05-04,Oxford/AstraZeneca,https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,67931,67931,0,
+Taiwan,2021-05-05,Oxford/AstraZeneca,https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,73988,73988,0,
+Taiwan,2021-05-06,Oxford/AstraZeneca,https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,80861,80861,0,
+Taiwan,2021-05-07,Oxford/AstraZeneca,https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,91002,91002,0,
+Taiwan,2021-05-09,Oxford/AstraZeneca,https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,92049,92049,0,
+Taiwan,2021-05-11,Oxford/AstraZeneca,https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,112543,112543,0,
+Taiwan,2021-05-12,Oxford/AstraZeneca,https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,129669,129669,0,
+Taiwan,2021-05-13,Oxford/AstraZeneca,https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,151997,151997,0,
+Taiwan,2021-05-14,Oxford/AstraZeneca,https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,186149,186149,0,
+Taiwan,2021-05-16,Oxford/AstraZeneca,https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,194678,194678,0,
+Taiwan,2021-05-17,Oxford/AstraZeneca,https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,220352,220352,0,
+Taiwan,2021-05-18,Oxford/AstraZeneca,https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,245008,245008,0,
+Taiwan,2021-05-19,Oxford/AstraZeneca,https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,264589,264589,0,
+Taiwan,2021-05-20,Oxford/AstraZeneca,https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,281647,281647,0,
+Taiwan,2021-05-21,Oxford/AstraZeneca,https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,299844,299844,0,
+Taiwan,2021-05-23,Oxford/AstraZeneca,https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,302698,302698,0,
+Taiwan,2021-05-24,Oxford/AstraZeneca,https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,311678,311678,0,
+Taiwan,2021-05-25,Oxford/AstraZeneca,https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,319665,319665,0,
+Taiwan,2021-06-02,Oxford/AstraZeneca,https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,562029,562029,0,
+Taiwan,2021-06-03,Oxford/AstraZeneca,https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,624132,624132,0,
+Taiwan,2021-06-04,Oxford/AstraZeneca,https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,678418,678418,0,
+Taiwan,2021-06-06,Oxford/AstraZeneca,https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,699187,699187,0,
+Taiwan,2021-06-07,Oxford/AstraZeneca,https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,724819,724819,0,
+Taiwan,2021-06-08,Oxford/AstraZeneca,https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,743578,743578,0,
+Taiwan,2021-06-09,Oxford/AstraZeneca,https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,759746,759746,0,
+Taiwan,2021-06-10,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,782300,782300,0,
+Taiwan,2021-06-11,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,799129,799129,0,
+Taiwan,2021-06-14,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,855125,855125,0,
+Taiwan,2021-06-15,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,1009160,985084,24076,
+Taiwan,2021-06-16,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,1178104,,,
+Taiwan,2021-06-17,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,1321839,,,
+Taiwan,2021-06-18,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,1429514,,,
+Taiwan,2021-06-20,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,1541732,,,
+Taiwan,2021-06-21,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,1616384,1587581,28803,
+Taiwan,2021-06-22,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,1681936,1652232,29704,
+Taiwan,2021-06-23,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,1746130,1714268,31862,
+Taiwan,2021-06-24,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,1835225,1801743,33482,
+Taiwan,2021-06-25,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,1905474,1869105,36369,
+Taiwan,2021-06-27,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,1926973,1890292,36681,
+Taiwan,2021-06-28,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,1964592,1926572,38020,
+Taiwan,2021-06-29,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,2002677,1962990,39687,
+Taiwan,2021-06-30,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,2043218,2001418,41800,
+Taiwan,2021-07-01,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,2087587,2044241,43346,
+Taiwan,2021-07-02,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,2278338,2232145,46193,
+Taiwan,2021-07-04,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,2518860,2472399,46461,
+Taiwan,2021-07-05,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,2628789,2581047,47742,
+Taiwan,2021-07-06,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,2740540,2691066,49474,
+Taiwan,2021-07-07,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,2899997,2847653,52344,
+Taiwan,2021-07-08,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,3121081,3060361,60720,
+Taiwan,2021-07-09,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,3357000,3284679,72321,
+Taiwan,2021-07-11,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,3565840,3492257,73583,
+Taiwan,2021-07-12,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,3821539,3742680,78859,
+Taiwan,2021-07-13,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,4084061,3998233,85828,
+Taiwan,2021-07-14,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,4337272,4242075,95197,
+Taiwan,2021-07-15,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,4603639,4496176,107463,
+Taiwan,2021-07-16,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,4916652,4790949,125703,
+Taiwan,2021-07-18,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,5194107,5064007,130100,
+Taiwan,2021-07-19,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,5419988,5279558,140430,
+Taiwan,2021-07-20,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,5674553,5520060,154493,
+Taiwan,2021-07-21,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,5894500,5718272,176228,
+Taiwan,2021-07-22,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,6059596,5858787,200809,
+Taiwan,2021-07-23,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,6347065,6117598,229467,
+Taiwan,2021-07-25,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,6674129,6433287,240842,
+Taiwan,2021-07-26,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,7013130,6751025,262105,
+Taiwan,2021-07-27,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,7318286,7030253,288033,
+Taiwan,2021-07-28,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,7588692,7273091,315601,
+Taiwan,2021-07-29,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,7826972,7484172,342800,
+Taiwan,2021-07-30,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,8088871,7707830,381041,
+Taiwan,2021-08-01,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,8270213,7881726,388487,
+Taiwan,2021-08-02,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,8405085,8001300,403785,
+Taiwan,2021-08-03,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,8501137,8083073,418064,
+Taiwan,2021-08-04,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,8607387,8170117,437270,
+Taiwan,2021-08-05,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,8875048,8418179,456869,
+Taiwan,2021-08-06,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,9154501,8661701,492800,
+Taiwan,2021-08-08,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,9180297,8679320,500977,
+Taiwan,2021-08-09,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,9228263,8709234,519029,
+Taiwan,2021-08-10,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,9265758,8725490,540268,
+Taiwan,2021-08-11,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,9433236,8867289,565947,
+Taiwan,2021-08-12,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,9602785,9006569,596216,
+Taiwan,2021-08-13,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,9749241,9100495,648746,
+Taiwan,2021-08-15,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,9824837,9162953,661884,
+Taiwan,2021-08-16,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,9887295,9203556,683739,
+Taiwan,2021-08-17,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,9951034,9247088,703946,
+Taiwan,2021-08-18,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,9985997,9260988,725009,
+Taiwan,2021-08-19,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,10014566,9269265,745301,
+Taiwan,2021-08-20,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,10057641,9285878,771763,
+Taiwan,2021-08-22,"Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,10067762,9290591,777171,
+Taiwan,2021-08-23,"Medigen, Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,10246977,9463223,783754,
+Taiwan,2021-08-24,"Medigen, Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,10404722,9602065,802657,
+Taiwan,2021-08-25,"Medigen, Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,10497159,9678947,818212,
+Taiwan,2021-08-26,"Medigen, Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,10586017,9742912,843105,
+Taiwan,2021-08-27,"Medigen, Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,10779334,9908979,870355,
+Taiwan,2021-08-29,"Medigen, Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,10886165,10005255,880910,
+Taiwan,2021-08-30,"Medigen, Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,10928720,10028069,900651,
+Taiwan,2021-08-31,"Medigen, Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,10958966,10038004,920962,
+Taiwan,2021-09-01,"Medigen, Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,10982471,10046132,936339,
+Taiwan,2021-09-02,"Medigen, Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,11004240,10051070,953170,
+Taiwan,2021-09-03,"Medigen, Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,11243600,10272559,971041,
+Taiwan,2021-09-05,"Medigen, Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,11380968,10399097,981871,
+Taiwan,2021-09-06,"Medigen, Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,11456359,10468680,987679,
+Taiwan,2021-09-07,"Medigen, Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,11548606,10552459,996147,
+Taiwan,2021-09-08,"Medigen, Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,11660683,10652241,1008442,
+Taiwan,2021-09-09,"Medigen, Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,11961678,10941158,1020520,
+Taiwan,2021-09-10,"Medigen, Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,12301555,11263210,1038345,
+Taiwan,2021-09-12,"Medigen, Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,12463192,11416544,1046648,
+Taiwan,2021-09-13,"Medigen, Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,12488096,11433445,1054651,
+Taiwan,2021-09-14,"Medigen, Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,12504662,11442116,1062546,
+Taiwan,2021-09-15,"Medigen, Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,12708428,11483332,1225096,
+Taiwan,2021-09-16,"Medigen, Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,12938098,11536036,1402062,
+Taiwan,2021-09-17,"Medigen, Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,13171843,11593038,1578805,
+Taiwan,2021-09-21,"Medigen, Moderna, Oxford/AstraZeneca",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,13405357,11689760,1715597,
+Taiwan,2021-09-22,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,13589767,11763739,1826028,
+Taiwan,2021-09-23,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,13856466,11912534,1943932,
+Taiwan,2021-09-24,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,14142461,12075243,2067218,
+Taiwan,2021-09-26,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,14430076,12278191,2151885,
+Taiwan,2021-09-27,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,14763330,12551676,2211654,
+Taiwan,2021-09-28,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,15091281,12812763,2278518,
+Taiwan,2021-09-29,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,15441421,13065648,2375773,
+Taiwan,2021-09-30,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,15880889,13243149,2637740,
+Taiwan,2021-10-01,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,16277198,13424778,2852420,
+Taiwan,2021-10-03,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,16558959,13477691,3081268,
+Taiwan,2021-10-04,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,16820590,13524914,3295676,
+Taiwan,2021-10-05,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,17021317,13577317,3444000,
+Taiwan,2021-10-06,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,17218445,13616764,3601681,
+Taiwan,2021-10-07,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,17541591,13666555,3875036,
+Taiwan,2021-10-08,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,17887465,13711680,4175785,
+Taiwan,2021-10-11,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,18240856,13759882,4480974,
+Taiwan,2021-10-12,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,18497356,13797381,4699975,
+Taiwan,2021-10-13,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,18766730,13980025,4786705,
+Taiwan,2021-10-14,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,19026022,14152139,4873883,
+Taiwan,2021-10-15,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,19435019,14395967,5039052,
+Taiwan,2021-10-17,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,19825683,14620207,5205476,
+Taiwan,2021-10-18,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,20204959,14877506,5327453,
+Taiwan,2021-10-19,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,20541421,15063365,5478056,
+Taiwan,2021-10-20,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,20920995,15229608,5691387,
+Taiwan,2021-10-21,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,21264787,15353595,5911192,
+Taiwan,2021-10-22,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,21717020,15555520,6161500,
+Taiwan,2021-10-24,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,22283271,15865789,6417482,
+Taiwan,2021-10-25,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,22783694,16105123,6678571,
+Taiwan,2021-10-26,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,23217629,16281201,6936428,
+Taiwan,2021-10-27,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,23637150,16404793,7232357,
+Taiwan,2021-10-28,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,24048734,16656545,7392189,
+Taiwan,2021-10-29,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,24481074,16951012,7530062,
+Taiwan,2021-10-31,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,24870150,17214718,7655432,
+Taiwan,2021-11-01,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,25182013,17286000,7896013,
+Taiwan,2021-11-02,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,25486269,17331396,8154873,
+Taiwan,2021-11-03,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,25778064,17384932,8393132,
+Taiwan,2021-11-04,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,25851240,17399450,8451790,
+Taiwan,2021-11-05,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,26080250,17436784,8643466,
+Taiwan,2021-11-07,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,26281921,17484037,8797884,
+Taiwan,2021-11-08,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,26542566,17557602,8984964,
+Taiwan,2021-11-09,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,26768810,17622921,9145889,
+Taiwan,2021-11-10,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,27004426,17689522,9314904,
+Taiwan,2021-11-11,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,27210265,17744846,9465419,
+Taiwan,2021-11-12,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,27479599,17808765,9670834,
+Taiwan,2021-11-14,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,27689479,17851199,9838280,
+Taiwan,2021-11-15,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,27927621,17891819,10035802,
+Taiwan,2021-11-16,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,28161546,17931470,10230076,
+Taiwan,2021-11-17,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,28403884,17961336,10442548,
+Taiwan,2021-11-18,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,28679327,17981769,10697558,
+Taiwan,2021-11-19,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,28986957,18016118,10970839,
+Taiwan,2021-11-22,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,29515207,18064753,11450454,
+Taiwan,2021-11-23,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,29749086,18087393,11661693,
+Taiwan,2021-11-24,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,29932419,18109173,11823246,
+Taiwan,2021-11-25,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,30254219,18136444,12117775,
+Taiwan,2021-11-26,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,30648405,18168092,12480313,
+Taiwan,2021-11-28,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,30965234,18193419,12771815,
+Taiwan,2021-11-29,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,31255998,18216396,13039602,
+Taiwan,2021-11-30,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,31546833,18246772,13300061,
+Taiwan,2021-12-01,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,31810156,18272135,13538021,
+Taiwan,2021-12-02,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,31998733,18281218,13717515,
+Taiwan,2021-12-03,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,32273067,18290428,13982639,
+Taiwan,2021-12-05,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,32471621,18302323,14169298,
+Taiwan,2021-12-06,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,32680126,18317806,14362320,
+Taiwan,2021-12-07,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,32885283,18338424,14546859,13118

--- a/scripts/src/cowidev/vax/incremental/taiwan.py
+++ b/scripts/src/cowidev/vax/incremental/taiwan.py
@@ -81,6 +81,7 @@ class Taiwan:
         stats = self._parse_stats(df)
         data = pd.Series(
             {
+                "total_boosters": stats["total_boosters"],
                 "total_vaccinations": stats["total_vaccinations"],
                 "people_vaccinated": stats["people_vaccinated"],
                 "date": self._parse_date(soup),
@@ -114,9 +115,11 @@ class Taiwan:
 
         num_dose1 = clean_count(df.loc["總計", "第 1劑"]["total"])
         num_dose2 = clean_count(df.loc["總計", "第 2劑"]["total"])
+        num_booster = clean_count(df.loc["總計", "追加劑"]["total"])
         return {
             "total_vaccinations": (num_dose1 + num_dose2),
             "people_vaccinated": num_dose1,
+            "total_boosters": num_booster,
         }
 
     def _parse_vaccines(self, df: pd.DataFrame) -> str:
@@ -162,6 +165,7 @@ class Taiwan:
                 date=data["date"],
                 source_url=data["source_url"],
                 vaccine=data["vaccine"],
+                total_boosters=data["total_boosters"],
             )
         else:
             increment(


### PR DESCRIPTION
I've patch the incremental parser to include the columne "total_booster" -- which has been provided since 2021-12-02. This seemed to create a larg diff on the output.. I'm not sure if it is ok.

Meanwhile I've manually typed in the those numbers for the past few days (commit 32d4c11eb4040a71303cc670d4599313c6615820)
