### PR TITLE
Taiwan.csv: manual updates for 2021-12-12

### DIFF
--- a/scripts/output/vaccinations/main_data/Taiwan.csv
+++ b/scripts/output/vaccinations/main_data/Taiwan.csv
@@ -217,3 +217,4 @@ Taiwan,2021-12-07,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https:
 Taiwan,2021-12-08,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,33071707,18355174,14716533,16557
 Taiwan,2021-12-09,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,33200156,18391917,14808239,22688
 Taiwan,2021-12-10,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,33374778,18436686,14938092,28850
+Taiwan,2021-12-12,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,33497204,18472049,15025155,30288


### PR DESCRIPTION
```
2021-12-14 00:30:03 ERROR    cowidev.vax.incremental.taiwan: ❌ There are some unknown columns: Index(['廠牌', '劑次', '12/11-12/12接種人次 累計至 12/12接種人次'], dtype='object')
```

The parser falied at such error -- which is caused by the fact that the source dataframe object `df` having a incorrate numebr of columens -- it become 3 instead of the usual 4 -- while the oveal table lookßlike it has 4 columns.

I'm not sure whether this is just a blip or if this is going to persist... so I decided to wait for a nother day before decding if a follow-up code changes is required.

Meanwhile, where's numbers that I manually typed in.
