### PR TITLE
fix(taiwan): relax the validation of column name a little bit.

### DIFF
--- a/scripts/output/vaccinations/main_data/Taiwan.csv
+++ b/scripts/output/vaccinations/main_data/Taiwan.csv
@@ -223,3 +223,4 @@ Taiwan,2021-12-14,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https:
 Taiwan,2021-12-15,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,33752634,18544759,15207875,40584
 Taiwan,2021-12-16,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,33814393,18562693,15251700,47494
 Taiwan,2021-12-17,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,33911110,18585322,15325788,56580
+Taiwan,2021-12-19,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,33972881,18602263,15370618,58750

--- a/scripts/src/cowidev/vax/incremental/taiwan.py
+++ b/scripts/src/cowidev/vax/incremental/taiwan.py
@@ -58,7 +58,7 @@ class Taiwan:
             and cols[0] == "廠牌"
             and cols[1] == "劑次"
             and cols[2].endswith("接種人次")
-            and re.match(r"(\d+\/\d+ *\- *)?\d+\/\d+ *接種人次", cols[2])
+            and re.match(r"(\d+\/\d+ *\- *)?\d+(\/\d+)? *接種人次", cols[2])
             and re.match(r"累計至 *\d+\/\d+ *接種人次", cols[3])
         ):
             raise ValueError(f"There are some unknown columns: {cols}")


### PR DESCRIPTION
The PDF released at 2021/12/20 come with a column titled:

    12/18-19接種人次

... while we've expected that to be:

    12/18-12/19接種人次

(date formats would likely be the last blocker of building a time machine.)