### PR TITLE
Manually add the entry of 2021/12/31 to Taiwan.csv

### DIFF
--- a/scripts/output/vaccinations/main_data/Taiwan.csv
+++ b/scripts/output/vaccinations/main_data/Taiwan.csv
@@ -233,3 +233,4 @@ Taiwan,2021-12-26,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https:
 Taiwan,2021-12-27,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,34412193,18676061,15736132,105759
 Taiwan,2021-12-28,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,34493865,18684915,15808950,116860
 Taiwan,2021-12-30,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,34824423,18706490,16117933,151423
+Taiwan,2021-12-31,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,38472136,18712858,16159278,158706


### PR DESCRIPTION
The PDF released on 2022/01/01 triggerd such error:

    ValueError: There are some unknown columns: Index(['廠牌 劑次', '110/12/31 接種人次', '累計至 110/12/31 接種人次'], dtype='object')

Similar to PR #2182, I'm guessing that this is due to a human error
that isn't likely to persist. Therefore I've only updated the CSV file
but not the parser.