### PR TITLE
Manually patch one entry to Taiwan.csv

### DIFF
--- a/scripts/output/vaccinations/main_data/Taiwan.csv
+++ b/scripts/output/vaccinations/main_data/Taiwan.csv
@@ -234,3 +234,4 @@ Taiwan,2021-12-27,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https:
 Taiwan,2021-12-28,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,34493865,18684915,15808950,116860
 Taiwan,2021-12-30,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,34824423,18706490,16117933,151423
 Taiwan,2021-12-31,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,38472136,18712858,16159278,158706
+Taiwan,2022-01-02,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,34890100,18716801,16173299,161763


### PR DESCRIPTION
The PDF released on 2022/01/03 still persists with the same error as

    ValueError: There are some unknown columns: Index(['廠牌 劑次', '110/12/31-111/1/2 接種人次', '累計至 111/1/2 接種人次'], dtype='object')

Which is the same as the one described in commit 67d5d3e1ab497d935c2d70da56aa0ed9cb4959bf

Previously: #2212, #2182 
