### PR TITLE
update taiwan.py parser for year 2022.

### DIFF
--- a/scripts/output/vaccinations/main_data/Taiwan.csv
+++ b/scripts/output/vaccinations/main_data/Taiwan.csv
@@ -235,3 +235,4 @@ Taiwan,2021-12-28,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https:
 Taiwan,2021-12-30,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,34824423,18706490,16117933,151423
 Taiwan,2021-12-31,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,34872136,18712858,16159278,158706
 Taiwan,2022-01-02,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,34890100,18716801,16173299,161763
+Taiwan,2022-01-03,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,34936462,18724023,16212439,169098

--- a/scripts/src/cowidev/vax/incremental/taiwan.py
+++ b/scripts/src/cowidev/vax/incremental/taiwan.py
@@ -60,8 +60,8 @@ class Taiwan:
             raise ValueError(f"There are some unknown columns: {cols}")
 
         # Fix index
-        df["劑次"] = df["劑次"].str.replace("\s+", "")
-        index_ = df["廠牌"].shift().fillna(method="bfill")
+        df["劑次"] = df["劑次"].str.replace("\s+", "", regex=True)
+        index_ = df["廠牌"].shift(periods=2).fillna(method="bfill")
         df["廠牌"] = index_
         df = df.set_index(["廠牌", "劑次"])
         # Drop NaNs
@@ -95,7 +95,8 @@ class Taiwan:
         num_dose1 = clean_count(df.loc["總計", "第1劑"]["total"])
         num_dose2 = clean_count(df.loc["總計", "第2劑"]["total"])
         num_booster1 = clean_count(df.loc["總計", "基礎加強劑"]["total"])
-        num_booster2 = clean_count(df.loc[pd.NA, "追加劑"]["total"])
+        num_booster2 = clean_count(df.loc["總計", "追加劑"]["total"])
+
         return {
             "total_vaccinations": num_dose1 + num_dose2,
             "people_vaccinated": num_dose1,
@@ -113,7 +114,7 @@ class Taiwan:
         date_raw = soup.find(class_="download").text
         regex = r"(\d{4})\sCOVID-19疫苗"
         date_str = re.search(regex, date_raw).group(1)
-        date_str = clean_date(f"2021{date_str}", fmt="%Y%m%d")
+        date_str = clean_date(f"2022{date_str}", fmt="%Y%m%d")
         return date_str
 
     def pipe_metrics(self, ds: pd.Series) -> pd.Series:


### PR DESCRIPTION
Happy new year :)

Luckly the errors in #2214 and #2212 did not persist. But we forgot to mark the date corrrectly so Taiwan.csv has not been updated eventhough all the numbers are extracted correctly.

Also I include a few changes that re-align first column so we don't take numbers from a 'NA' row with others as well cleaning up this FutureWaring, which I encountered when running with python3.9
 
    FutureWarning: The default value of regex will change from True to False in a future version

