### PR TITLE
manual update of Taiwan.csv for 2022-01-04.

### DIFF
--- a/scripts/output/vaccinations/main_data/Taiwan.csv
+++ b/scripts/output/vaccinations/main_data/Taiwan.csv
@@ -236,3 +236,4 @@ Taiwan,2021-12-30,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https:
 Taiwan,2021-12-31,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,34872136,18712858,16159278,158706
 Taiwan,2022-01-02,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,34890100,18716801,16173299,161763
 Taiwan,2022-01-03,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,34936462,18724023,16212439,169098
+Taiwan,2022-01-04,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,34993341,18732602,16260739,180662


### PR DESCRIPTION
The PDF released on 202-01-05 (containing stats for 2022-01-04)
shows this error again:

    ValueError: There are some unknown columns: Index(['廠牌 劑次', '1/4 接種人次', '累計至 1/4 接種人次'], dtype='object')

Previously: #2214 and #2212. commit b9bd39a9477dde087287f6307fa4d01b62e4aa78 and 67d5d3e1ab497d935c2d70da56aa0ed9cb4959bf