### PR TITLE
Fix taiwan parser pdf link extraction

### DIFF
--- a/scripts/output/vaccinations/main_data/Taiwan.csv
+++ b/scripts/output/vaccinations/main_data/Taiwan.csv
@@ -242,3 +242,4 @@ Taiwan,2022-01-06,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https:
 Taiwan,2022-01-07,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,35306926,18766646,16540280,274304
 Taiwan,2022-01-12,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,35538991,18812827,16726164,852096
 Taiwan,2022-01-14,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,35698752,18846087,16852665,1432500
+Taiwan,2022-01-16,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,35772279,18865900,16906379,1696477


### PR DESCRIPTION
Usually the PDF URLs harvested from the download page[1] would respond
an HTML UI that is the viewer of the actual pdf with a download link,
but occassionally the same URL gives directly leads to the actual pdf,
without revealing the viewer.

Such behaviour seems to be decided on the server-side. Luckily enough
though, the server properly sents the correct Content-Type so we can
basiaclly assume that when it is "application/pdf", we found the pdf url.

The column names are also changed -- the "dates" now contain 3-digits
that is the ROC year.

[1]: https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og
