### PR TITLE
data(vax): update

### DIFF
--- a/public/data/vaccinations/country_data/Thailand.csv
+++ b/public/data/vaccinations/country_data/Thailand.csv
@@ -240,3 +240,19 @@ Thailand,2021-12-15,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinopharm/Beijing, Sin
 Thailand,2021-12-18,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinopharm/Beijing, Sinovac",https://ddc.moph.go.th/vaccine-covid19/getFiles/9/1639985699292.pdf,99385119,50438629,44194781,4751709
 Thailand,2021-12-23,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinopharm/Beijing, Sinovac",https://ddc.moph.go.th/vaccine-covid19/getFiles/9/1640233760913.pdf,101079615,50768299,44819727,5491589
 Thailand,2021-12-27,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinopharm/Beijing, Sinovac",https://ddc.moph.go.th/vaccine-covid19/getFiles/9/1640658406662.pdf,102681943,51032649,45423045,6226249
+Thailand,2021-12-30,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinopharm/Beijing, Sinovac",https://ddc.moph.go.th/vaccine-covid19/getFiles/9/1641440733843.pdf,103894611,51205920,45928719,6759972
+Thailand,2022-01-01,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinopharm/Beijing, Sinovac, Moderna",https://ddc.moph.go.th/vaccine-covid19/getFiles/9/1641441511795.pdf,104444169,51295617,46145566,7002986
+Thailand,2022-01-02,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinopharm/Beijing, Sinovac, Moderna",https://ddc.moph.go.th/vaccine-covid19/getFiles/9/1641441668654.pdf,104472167,51301610,46155460,7015097
+Thailand,2022-01-03,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinopharm/Beijing, Sinovac, Moderna",https://ddc.moph.go.th/vaccine-covid19/getFiles/9/1641441823930.pdf,104491859,51305090,46161437,7025332
+Thailand,2022-01-04,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinopharm/Beijing, Sinovac, Moderna",https://ddc.moph.go.th/vaccine-covid19/getFiles/9/1641442017690.pdf,104524571,51310112,46172663,7041796
+Thailand,2022-01-07,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinopharm/Beijing, Sinovac, Moderna",https://ddc.moph.go.th/vaccine-covid19/getFiles/9/164188749782.pdf,105419287,51409711,46526520,7483056
+Thailand,2022-01-08,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinopharm/Beijing, Sinovac, Moderna",https://ddc.moph.go.th/vaccine-covid19/getFiles/9/1641887714906.pdf,105953235,51463230,46704515,7785490
+Thailand,2022-01-09,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinopharm/Beijing, Sinovac, Moderna",https://ddc.moph.go.th/vaccine-covid19/getFiles/9/1641887832753.pdf,106336237,51502025,46820621,8013591
+Thailand,2022-01-10,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinopharm/Beijing, Sinovac, Moderna",https://ddc.moph.go.th/vaccine-covid19/getFiles/9/1641887946949.pdf,106475122,51514791,46853598,8106733
+Thailand,2022-01-11,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinopharm/Beijing, Sinovac, Moderna",https://ddc.moph.go.th/vaccine-covid19/getFiles/9/1642474913364.pdf,106758696,51543088,46923112,8292496
+Thailand,2022-01-12,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinopharm/Beijing, Sinovac, Moderna",https://ddc.moph.go.th/vaccine-covid19/getFiles/9/1642475093557.pdf,107271904,51592872,47056159,8622873
+Thailand,2022-01-13,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinopharm/Beijing, Sinovac, Moderna",https://ddc.moph.go.th/vaccine-covid19/getFiles/9/1642482619282.pdf,107771259,51642575,47172252,8956432
+Thailand,2022-01-14,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinopharm/Beijing, Sinovac, Moderna",https://ddc.moph.go.th/vaccine-covid19/getFiles/9/1642482746330.pdf,108313948,51694907,47301137,9317904
+Thailand,2022-01-15,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinopharm/Beijing, Sinovac, Moderna",https://ddc.moph.go.th/vaccine-covid19/getFiles/9/1642482886956.pdf,108916435,51751305,47445961,9719169
+Thailand,2022-01-16,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinopharm/Beijing, Sinovac, Moderna",https://ddc.moph.go.th/vaccine-covid19/getFiles/9/1642483021905.pdf,109369708,51794886,47551074,10023748
+Thailand,2022-01-17,"Oxford/AstraZeneca, Pfizer/BioNTech, Sinopharm/Beijing, Sinovac, Moderna",https://ddc.moph.go.th/vaccine-covid19/getFiles/9/1642483133520.pdf,109542145,51809191,47579865,10153089


### PR DESCRIPTION
Update for latest Thailand Vaccination Data from
https://ddc.moph.go.th/vaccine-covid19/diaryReport (Thai Language)

Note: Government starts offer Moderna around November (unknown date) 