### PR TITLE
Fix taiwan pdf table column name validation 20220118

### DIFF
--- a/scripts/output/vaccinations/main_data/Taiwan.csv
+++ b/scripts/output/vaccinations/main_data/Taiwan.csv
@@ -243,3 +243,4 @@ Taiwan,2022-01-07,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https:
 Taiwan,2022-01-12,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,35538991,18812827,16726164,852096
 Taiwan,2022-01-14,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,35698752,18846087,16852665,1432500
 Taiwan,2022-01-16,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,37468756,18865900,16906379,1696477
+Taiwan,2022-01-17,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,37917556,18881397,16950016,2086143

--- a/scripts/src/cowidev/vax/incremental/taiwan.py
+++ b/scripts/src/cowidev/vax/incremental/taiwan.py
@@ -61,8 +61,8 @@ class Taiwan:
             and cols[0] == "廠牌"
             and cols[1] == "劑次"
             and cols[2].endswith("接種人次")
-            and re.match(r"(\d+/\d+\/\d+ *\- *)?(\d+/(\d+\/)?)?\d+? *接種人次", cols[2])
-            and re.match(r"累計至 *\d+/\d+\/\d+ *接種人次", cols[3])
+            and re.match(r"((\d+/)?\d+\/\d+ *\- *)?(\d+/(\d+\/)?)?\d+? *接種人次", cols[2])
+            and re.match(r"累計至 *(\d+/)?\d+\/\d+ *接種人次", cols[3])
         ):
             raise ValueError(f"There are some unknown columns: {cols}")
 


### PR DESCRIPTION
In #2275 I changed the column name validation to support format `yyy/mm/dd` since that the format used in the pdf released at 2022/01/17. However in the pdf released at 2022/01/18, the date formatin the table header is in `mm/dd`.

The regex is updated to support both formats.

