### PR TITLE
(tests, zambia): drop erroneous data point

### DIFF
--- a/scripts/src/cowidev/testing/batch/zambia.py
+++ b/scripts/src/cowidev/testing/batch/zambia.py
@@ -53,7 +53,7 @@ class Zambia(CountryTestBase):
         df = df[df["Cumulative total"] > 0]
         df = df.groupby("Cumulative total", as_index=False).min()
         df = df.groupby("Date", as_index=False).min()
-        # manual fix: drop incorrect data point
+        # manual fix: drop incorrect data point on 2021-10-30
         df = df.drop(index=df[df["Date"] == "2021-10-30"].index.values)
         df = make_monotonic(df)
         return df


### PR DESCRIPTION
Incorrect data point at 2021-10-30 was causing the script to crash