### PR TITLE
fix taiwan.py: update parse_date according to change of file name.

### DIFF
--- a/scripts/output/vaccinations/main_data/Taiwan.csv
+++ b/scripts/output/vaccinations/main_data/Taiwan.csv
@@ -256,3 +256,4 @@ Taiwan,2022-01-27,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https:
 Taiwan,2022-01-28,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,41984449,19091332,17443080,5450037
 Taiwan,2022-02-06,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,42304177,19128417,17500885,5674875
 Taiwan,2022-02-07,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,42494576,19143317,17522132,5829127
+Taiwan,2022-02-08,"Medigen, Moderna, Oxford/AstraZeneca, Pfizer/BioNTech",https://www.cdc.gov.tw/Category/Page/9jFXNbCe-sFK9EImRRi2Og,42711112,19158088,17547825,6005199

--- a/scripts/src/cowidev/vax/incremental/taiwan.py
+++ b/scripts/src/cowidev/vax/incremental/taiwan.py
@@ -123,7 +123,7 @@ class Taiwan:
 
     def _parse_date(self, soup) -> str:
         date_raw = soup.find(class_="download").text
-        regex = r"(\d{4})\sCOVID-19疫苗"
+        regex = r"(\d{4})\s*COVID-19疫苗"
         date_str = re.search(regex, date_raw).group(1)
         date_str = clean_date(f"2022{date_str}", fmt="%Y%m%d")
         return date_str


### PR DESCRIPTION
currently parse_date is derived from file name, which used to contain
a whitespace character as the delimiter between date and
non-date. Such as this:

    1110207 COVID-19疫苗接種統計資料.pdf

But the file for 2022/02/08 is named differently like this:

    1110208COVID-19疫苗接種統計資料.pdf

Since this change might persists or not, the regex is augmented to
accept both variants.