### PR TITLE
Ukraine add total_boosters vaccination info

### DIFF
--- a/scripts/src/cowidev/vax/batch/ukraine.py
+++ b/scripts/src/cowidev/vax/batch/ukraine.py
@@ -68,15 +68,10 @@ class Ukraine:
         total_df = main_df.join(booster_df.set_index("date"), on=["date"])
 
         for col in ["total", "moderna", "astrazeneca", "pfizer", "jnj", "sinovac"]:
-            total_df[f"booster_dose_{col}"] = (
-                total_df[f"third_dose_{col}"] +
-                total_df[f"additional_dose_{col}"]
-            )
+            total_df[f"booster_dose_{col}"] = total_df[f"third_dose_{col}"] + total_df[f"additional_dose_{col}"]
 
             total_df[f"all_doses_{col}"] = (
-                total_df[f"first_dose_{col}"] +
-                total_df[f"second_dose_{col}"] +
-                total_df[f"booster_dose_{col}"]
+                total_df[f"first_dose_{col}"] + total_df[f"second_dose_{col}"] + total_df[f"booster_dose_{col}"]
             )
 
         total_df = total_df.assign(location=self.location, source_url=self.source_url)
@@ -100,11 +95,12 @@ class Ukraine:
         return df
 
     def pipe_metrics(self, df: pd.DataFrame) -> pd.DataFrame:
-        df["total_vaccinations"] = df["second_dose_total"] + df["first_dose_total"] + df["booster_dose_total"]
-        df["people_fully_vaccinated"] = df["second_dose_total"] + df["first_dose_jnj"]
-        df.rename(columns={"first_dose_total": "people_vaccinated"}, inplace=True)
-        df.rename(columns={"booster_dose_total": "total_boosters"}, inplace=True)
-        return df
+        return df.assign(
+            total_vaccinations=df["second_dose_total"] + df["first_dose_total"] + df["booster_dose_total"],
+            people_vaccinated=df["first_dose_total"],
+            people_fully_vaccinated=df["second_dose_total"] + df["first_dose_jnj"],
+            total_boosters=df["booster_dose_total"],
+        )
 
     def pipeline(self, df: pd.DataFrame) -> pd.DataFrame:
         return (
@@ -119,7 +115,7 @@ class Ukraine:
                     "total_vaccinations",
                     "people_vaccinated",
                     "people_fully_vaccinated",
-                    "total_boosters"
+                    "total_boosters",
                 ]
             ]
             .sort_values(["date"])

--- a/scripts/src/cowidev/vax/batch/ukraine.py
+++ b/scripts/src/cowidev/vax/batch/ukraine.py
@@ -56,15 +56,14 @@ class Ukraine:
         return df
 
     def read(self):
+        # Read doses
         first_dose_df = self._load_dose_data(dose_param="1", colname="first_dose")
         second_dose_df = self._load_dose_data(dose_param="2", colname="second_dose")
-
         additional_dose_df = self._load_dose_data(dose_param="A", colname="additional_dose")
         booster_dose_df = self._load_dose_data(dose_param="3", colname="third_dose")
-
+        # Build df
         booster_df = booster_dose_df.join(additional_dose_df.set_index("date"), on=["date"])
         main_df = first_dose_df.join(second_dose_df.set_index("date"), on=["date"])
-
         total_df = main_df.join(booster_df.set_index("date"), on=["date"])
 
         for col in ["total", "moderna", "astrazeneca", "pfizer", "jnj", "sinovac"]:
@@ -133,7 +132,7 @@ class Ukraine:
 
         vac_dfs = []
         for vaccine, col in zip(vaccine_name, column_name):
-            vac_df = df[["location", "date", col]]
+            vac_df = df[["location", "date", col]].copy()
             vac_df["vaccine"] = vaccine
             vac_df.rename(columns={col: "total_vaccinations"}, inplace=True)
             vac_df = vac_df[vac_df["total_vaccinations"] > 0]


### PR DESCRIPTION
This is a PR that add the **total_boosters** data for Ukraine, however, IDK exactly how should we properly handle this data

From the point of Ukraine's Ministry of Health, it is possible to get an **additional dose** and a **booster dose** (this is not a new concept, afaik this is the same as in the USA)

An additional dose is a dose that is dedicated for people with low immunity reaction (most often this is people with HIV/cancer). The additional dose can be done after 28 days after the second dose. Ukraine statistics count this type of vaccination most of all as a separate entity or rarely sum it up with a second dose. As for now, around **20k** people have this type of vaccination 

Government dashboard with additional and booster doses on it (https://vaccination.covid19.gov.ua/)
Additional info: https://uatv.ua/en/health-ministry-approved-a-booster-dose-uatv-studied-difference-with-an-additional-vaccine/

A booster dose is a "classic" booster vaccination that is available for all people in the country, around **500k** people have already done the booster in Ukraine.

Current realization sums up the additional and booster doses together and counts them as a booster. Summing up additional and second may lead to misunderstanding in reading the statistics, however, if the database standard is to count these doses as second doses or not count at all, I can easily fix this in the scope of this PR