### PR TITLE
enhance(vax, singapore): Removing filter

### DIFF
--- a/scripts/src/cowidev/vax/batch/singapore.py
+++ b/scripts/src/cowidev/vax/batch/singapore.py
@@ -98,7 +98,7 @@ class Singapore(CountryVaxBase):
             df.pipe(self.pipe_rename_columns)
             .pipe(self.pipe_metrics)
             .pipe(self.pipe_metadata)
-            .pipe(self.pipe_filter_dp)
+            #.pipe(self.pipe_filter_dp)
             .pipe(make_monotonic, max_removed_rows=20)
         )
 


### PR DESCRIPTION
The filter is redundant since `make_monotonic` will remove the anomalies in the data. Having the filter, disables the script to record the data points, if they are corrected by the source.  