### PR TITLE
docs: update frequency

### DIFF
--- a/public/data/README.md
+++ b/public/data/README.md
@@ -7,7 +7,7 @@ Our complete COVID-19 dataset is a collection of the COVID-19 data maintained by
 
 | Metrics                     | Source                                                    | Updated | Countries |
 |-----------------------------|-----------------------------------------------------------|---------|-----------|
-| Vaccinations                | Official data collated by the Our World in Data team      | Daily   | 218       |
+| Vaccinations                | Official data collated by the Our World in Data team      | Every weekday   | 218       |
 | Tests & positivity          | Official data collated by the Our World in Data team      | Weekly  | 178       |
 | Hospital & ICU              | Official data collated by the Our World in Data team      | Daily   | 47        |
 | Confirmed cases             | JHU CSSE COVID-19 Data                                    | Daily   | 216        |

--- a/public/data/README.md
+++ b/public/data/README.md
@@ -186,6 +186,7 @@ If you are interested in the individual files that make up the complete dataset,
 - On 28 September 2021, we changed the way we estimate the excess mortality. More details [here](https://github.com/owid/covid-19-data/tree/master/public/data/excess_mortality#how-p-scores-are-defined-and-calculated). We also added 3 new variables to our complete dataset: `excess_mortality_cumulative` (cumulative % of excess deaths), `excess_mortality_cumulative_absolute` (cumulative count of absolute excess deaths), `excess_mortality_cumulative_per_million` (cumulative count of excess deaths per million people).
 - On 15 November 2021, we added the metrics `new_people_vaccinated_smoothed` and `new_people_vaccinated_smoothed_per_hundred` to our vaccination data. They count the daily number of people receiving their first vaccine dose.
 - On 27 December 2021, we added a [specific folder for our hospitalizations & ICU data](https://github.com/owid/covid-19-data/tree/master/public/data/hospitalizations).
+- Since 29 March 2022, vaccination data is no longer updated on a daily basis. Updates now are only on weekdays (Monday until Friday).
 
 ## Data alterations
 

--- a/scripts/docs/data-pipeline.md
+++ b/scripts/docs/data-pipeline.md
@@ -19,7 +19,7 @@ tasks.
 
 | **Pipeline**              | **Frequency**                | **Tasks**                             |
 |---------------------------|------------------------------|------------------------------------------|
-| [Vaccinations](#vaccinations-pipeline)               | daily at 12:00 UTC           | {abbr}`Collection (Scraping primary sources (e.g. country governmental sites) and extracting relevant datapoints.)`, {abbr}`transformation (Transforming and cleaning the downloaded data into a human-readable format.)`, {abbr}`presentation (Presenting the cleaned data to the public (e.g. charts, dataset files, etc.).)` |
+| [Vaccinations](#vaccinations-pipeline)               | every weekday at 12:00 UTC           | {abbr}`Collection (Scraping primary sources (e.g. country governmental sites) and extracting relevant datapoints.)`, {abbr}`transformation (Transforming and cleaning the downloaded data into a human-readable format.)`, {abbr}`presentation (Presenting the cleaned data to the public (e.g. charts, dataset files, etc.).)` |
 | [Testing](#testing-pipeline)                   | 3 times per week             | Collection, transformation, presentation |
 | [Hospitalization & ICU](#hospitalization-icu-pipeline)     | daily at 06:00 and 18:00 UTC | Collection, transformation, presentation |
 | [Cases & Deaths (JHU)](#cases-deaths-jhu-pipeline)      | every hour (if new data)     | Transformation, presentation             |
@@ -35,8 +35,8 @@ You can find all the automation details [in this file](https://github.com/owid/c
 The vaccination pipeline is probably the most complete one, where we scrape and extract data for each country in the
 dataset.
 
-The pipeline is executed manually, by [@edomt](https://github.com/edomt) or [@lucasrodes](https://github.com/lucasrodes) on
-a daily basis before 12 UTC.
+The pipeline is executed manually, by [@edomt](https://github.com/edomt) or [@lucasrodes](https://github.com/lucasrodes)
+evry weekday (i.e. Monday until Friday) before 12 UTC.
 
 ### Execution steps
 ```

--- a/scripts/docs/data-pipeline.md
+++ b/scripts/docs/data-pipeline.md
@@ -36,7 +36,7 @@ The vaccination pipeline is probably the most complete one, where we scrape and 
 dataset.
 
 The pipeline is executed manually, by [@edomt](https://github.com/edomt) or [@lucasrodes](https://github.com/lucasrodes)
-evry weekday (i.e. Monday until Friday) before 12 UTC.
+every weekday (i.e. Monday until Friday) before 12 UTC.
 
 ### Execution steps
 ```

--- a/scripts/scripts/README.md.template
+++ b/scripts/scripts/README.md.template
@@ -93,6 +93,7 @@ If you are interested in the individual files that make up the complete dataset,
 - On 28 September 2021, we changed the way we estimate the excess mortality. More details [here](https://github.com/owid/covid-19-data/tree/master/public/data/excess_mortality#how-p-scores-are-defined-and-calculated). We also added 3 new variables to our complete dataset: `excess_mortality_cumulative` (cumulative % of excess deaths), `excess_mortality_cumulative_absolute` (cumulative count of absolute excess deaths), `excess_mortality_cumulative_per_million` (cumulative count of excess deaths per million people).
 - On 15 November 2021, we added the metrics `new_people_vaccinated_smoothed` and `new_people_vaccinated_smoothed_per_hundred` to our vaccination data. They count the daily number of people receiving their first vaccine dose.
 - On 27 December 2021, we added a [specific folder for our hospitalizations & ICU data](https://github.com/owid/covid-19-data/tree/master/public/data/hospitalizations).
+- Since 29 March 2022, vaccination data is no longer updated on a daily basis. Updates now are only on weekdays (Monday until Friday).
 
 ## Data alterations
 

--- a/scripts/scripts/README.md.template
+++ b/scripts/scripts/README.md.template
@@ -7,7 +7,7 @@ Our complete COVID-19 dataset is a collection of the COVID-19 data maintained by
 
 | Metrics                     | Source                                                    | Updated | Countries |
 |-----------------------------|-----------------------------------------------------------|---------|-----------|
-| Vaccinations                | Official data collated by the Our World in Data team      | Daily   | {num_countries_vaccinations}       |
+| Vaccinations                | Official data collated by the Our World in Data team      | Every weekday   | {num_countries_vaccinations}       |
 | Tests & positivity          | Official data collated by the Our World in Data team      | Weekly  | {num_countries_testing}       |
 | Hospital & ICU              | Official data collated by the Our World in Data team      | Daily   | {num_countries_hospital}        |
 | Confirmed cases             | JHU CSSE COVID-19 Data                                    | Daily   | {num_countries_cases}        |


### PR DESCRIPTION
This PR updates the documentation to reflect our new update frequency policy for the vaccinations dataset (see https://github.com/owid/covid-19-data/issues/2586).

Once approved:
- PR will be merged
- Documentation at https://covid-docs.ourworldindata.org/en/latest/ will be updated.
- An announcement in discussions will be published.


