### PR TITLE
fix(jhu): Hide China death data correction on 2020-04-17

### DIFF
--- a/scripts/src/cowidev/jhu/__main__.py
+++ b/scripts/src/cowidev/jhu/__main__.py
@@ -48,6 +48,7 @@ LARGE_DATA_CORRECTIONS = [
     ("Brazil", "2021-09-18", "cases"),
     ("Chile", "2020-07-17", "deaths"),
     ("Chile", "2022-03-21", "deaths"),
+    ("China", "2020-04-17", "deaths"),
     ("Denmark", "2021-12-21", "deaths"),
     ("Ecuador", "2020-09-07", "deaths"),
     ("Ecuador", "2021-07-20", "deaths"),


### PR DESCRIPTION
Source: <http://www.nhc.gov.cn/xcs/yqtb/202004/9d15772389c64d478713e710a756b883.shtml>.