### PR TITLE
fix(vax,fra): Add Pfizer/BioNTech pediatric version and Novavax

### DIFF
--- a/scripts/src/cowidev/vax/batch/france.py
+++ b/scripts/src/cowidev/vax/batch/france.py
@@ -18,6 +18,8 @@ class France(CountryVaxBase):
             2: "Moderna",
             3: "Oxford/AstraZeneca",
             4: "Johnson&Johnson",
+            5: "Pfizer/BioNTech",
+            6: "Novavax",
         }
         one_dose_vaccines = ["Johnson&Johnson"]
 
@@ -53,6 +55,7 @@ class France(CountryVaxBase):
         df = df[(df.vaccine.isin(vaccine_mapping.keys())) & (df.n_cum_dose1 > 0)]
         assert set(df["vaccine"].unique()) == set(vaccine_mapping.keys())
         df["vaccine"] = df.vaccine.replace(vaccine_mapping)
+        df = df.groupby(["vaccine", "date"], as_index=False).sum()
 
         df["total_vaccinations"] = df.n_cum_dose1 + df.n_cum_dose2 + df.n_cum_dose3 + df.n_cum_dose4
         df["people_vaccinated"] = df.n_cum_dose1


### PR DESCRIPTION
Update according to <https://www.data.gouv.fr/fr/datasets/donnees-relatives-aux-personnes-vaccinees-contre-la-covid-19-1/>.

This will affect the data since 2021-12-14. See also #2630.