### PR TITLE
fix(vax,chn): ❗ Redesign regex & merge pipeline

### DIFF
--- a/scripts/src/cowidev/vax/incremental/china.py
+++ b/scripts/src/cowidev/vax/incremental/china.py
@@ -138,10 +138,14 @@ class China(CountryVaxBase):
         # Use total_vaccinations from df_last & df
         dates = df_complete.index[msk]
         df_complete.loc[dates, "total_vaccinations"] = df_last.total_vaccinations[dates]
-        for metric in ["people_vaccinated", "total_boosters"]:
-            # Avoid clearing previous people_vaccinated & total_boosters
+        for metric in ["people_vaccinated", "people_fully_vaccinated", "total_boosters"]:
+            # Avoid clearing previously saved metrics
             dates = df_complete.index[msk & df_complete[metric].isna()]
             df_complete.loc[dates, metric] = df_last.loc[dates, metric]
+            for date, m in df_complete[metric].items():
+                # Check abnormally decreased metrics
+                if date >= df_last.index.max() and m < 0.99 * df_last[metric].max():
+                    raise ValueError(f"Abnormally decreased {metric}: {m:.0f} ({date})")
         if not df.empty:
             df = df.set_index("date")
             msk = df.index.isin(df_complete.index)


### PR DESCRIPTION
The regex breaks again for the total_boosters on 2022-05-22 (you will see a significant drop tomorrow). It is now necessary to redesign the regex and the merge pipeline:
1. The new regex only focuses on keywords and tolerates the potential changes in the Chinese language as many as possible: https://github.com/owid/covid-19-data/blob/9a346b8e95de5048b3ba1e7af102cfc9b419ef91/scripts/src/cowidev/vax/incremental/china.py#L22-L32
2. The new merge pipeline avoids saving the inaccurate total_vaccinations or clearing previously saved metrics or saving abnormally decreased metrics: https://github.com/owid/covid-19-data/blob/9a346b8e95de5048b3ba1e7af102cfc9b419ef91/scripts/src/cowidev/vax/incremental/china.py#L135-L156
3. The previous source goes back to normal. Since it is faster, it is better to switch back: https://github.com/owid/covid-19-data/blob/9a346b8e95de5048b3ba1e7af102cfc9b419ef91/scripts/src/cowidev/vax/incremental/china.py#L15