### PR TITLE
enhance: support a remote grapher server for deploys

### DIFF
--- a/scripts/.env.example
+++ b/scripts/.env.example
@@ -4,5 +4,5 @@ DB_PORT=3306
 DB_USER="user"
 DB_PASS="password"
 
-# DEPLOY_QUEUE_PATH="/path/to/.queue"
+# DEPLOY_QUEUE_PATH="owid-live:/home/owid/live/.queue"
 # SLACK_API_TOKEN=""

--- a/scripts/.env.example
+++ b/scripts/.env.example
@@ -4,5 +4,5 @@ DB_PORT=3306
 DB_USER="user"
 DB_PASS="password"
 
-# DEPLOY_QUEUE_PATH="owid-live:/home/owid/live/.queue"
+# DEPLOY_QUEUE_PATH="server:path/to/.queue"
 # SLACK_API_TOKEN=""

--- a/scripts/scripts/utils/db_imports.py
+++ b/scripts/scripts/utils/db_imports.py
@@ -28,22 +28,24 @@ sys.path.append(os.path.join(CURRENT_DIR, ".."))
 USER_ID = 46
 
 # Dataset namespace
-NAMESPACE = 'owid'
+NAMESPACE = "owid"
 
-DEPLOY_QUEUE_PATH = os.getenv('DEPLOY_QUEUE_PATH')
+DEPLOY_QUEUE_PATH = os.getenv("DEPLOY_QUEUE_PATH")
 
 
 def print_err(*args, **kwargs):
     return print(*args, file=sys.stderr, **kwargs)
 
+
 def chunk_df(df, n):
     """Yield successive n-sized chunks from data frame."""
     for i in range(0, df.shape[0], n):
-        yield df[i:i + n]
+        yield df[i : i + n]
 
 
 tz_utc = tz_db = timezone.utc
 tz_local = datetime.now(tz_utc).astimezone().tzinfo
+
 
 def import_dataset(dataset_name, namespace, csv_path, default_variable_display, source_name, slack_notifications=True):
     print(dataset_name.upper())
@@ -57,12 +59,15 @@ def import_dataset(dataset_name, namespace, csv_path, default_variable_display, 
         # This is not bulletproof, but it allows for flexibility – authors could manually update
         # the repo, and that would trigger a database update too.
 
-        (db_dataset_id, db_dataset_modified_time) = db.fetch_one("""
+        (db_dataset_id, db_dataset_modified_time) = db.fetch_one(
+            """
             SELECT id, dataEditedAt
             FROM datasets
             WHERE name = %s
             AND namespace = %s
-        """, [dataset_name, namespace])
+        """,
+            [dataset_name, namespace],
+        )
 
         db_dataset_modified_time = db_dataset_modified_time.replace(tzinfo=tz_db)
         file_modified_time = datetime.fromtimestamp(os.stat(csv_path).st_mtime).replace(tzinfo=tz_local)
@@ -81,15 +86,18 @@ def import_dataset(dataset_name, namespace, csv_path, default_variable_display, 
         # Check whether all entities exist in the database.
         # If some are missing, report & quit.
 
-        entity_names = list(df['Country'].unique())
+        entity_names = list(df["Country"].unique())
 
-        db_entities_query = db.fetch_many("""
+        db_entities_query = db.fetch_many(
+            """
             SELECT id, name
             FROM entities
             WHERE name IN %s
-        """, [entity_names])
+        """,
+            [entity_names],
+        )
 
-        db_entity_id_by_name = { name: id for id, name in db_entities_query }
+        db_entity_id_by_name = {name: id for id, name in db_entities_query}
 
         # Terminate if some entities are missing from the database
         missing_entity_names = set(entity_names) - set(db_entity_id_by_name.keys())
@@ -99,24 +107,30 @@ def import_dataset(dataset_name, namespace, csv_path, default_variable_display, 
 
         # Fetch the source
 
-        (db_source_id,) = db.fetch_one("""
+        (db_source_id,) = db.fetch_one(
+            """
             SELECT id
             FROM sources
             WHERE datasetId = %s
-        """, db_dataset_id)
+        """,
+            db_dataset_id,
+        )
 
         # Check whether all variables match database variables.
 
         id_names = ["Country", "Year"]
         variable_names = list(set(df.columns) - set(id_names))
 
-        db_variables_query = db.fetch_many("""
+        db_variables_query = db.fetch_many(
+            """
             SELECT id, name
             FROM variables
             WHERE datasetId = %s
-        """, [db_dataset_id])
+        """,
+            [db_dataset_id],
+        )
 
-        db_variable_id_by_name = { name: id for id, name in db_variables_query }
+        db_variable_id_by_name = {name: id for id, name in db_variables_query}
 
         # Remove any variables no longer in the dataset. This is safe because any variables used in
         # charts won't be deleted because of database constrant checks.
@@ -124,13 +138,16 @@ def import_dataset(dataset_name, namespace, csv_path, default_variable_display, 
         variable_names_to_remove = list(set(db_variable_id_by_name.keys()) - set(variable_names))
         if len(variable_names_to_remove):
             print(f"Removing variables: {str(variable_names_to_remove)}")
-            variable_ids_to_remove = [ db_variable_id_by_name[n] for n in variable_names_to_remove ]
-            db.execute("""
+            variable_ids_to_remove = [db_variable_id_by_name[n] for n in variable_names_to_remove]
+            db.execute(
+                """
                 DELETE FROM data_values
                 WHERE variableId IN %(ids)s;
                 DELETE FROM variables
                 WHERE id IN %(ids)s;
-            """, { 'ids': variable_ids_to_remove })
+            """,
+                {"ids": variable_ids_to_remove},
+            )
 
         # Add variables that didn't exist before. Make sure to set yearIsDay.
 
@@ -141,65 +158,81 @@ def import_dataset(dataset_name, namespace, csv_path, default_variable_display, 
                 db_variable_id_by_name[name] = db.upsert_variable(
                     name=name,
                     code=None,
-                    unit='',
+                    unit="",
                     short_unit=None,
                     source_id=db_source_id,
                     dataset_id=db_dataset_id,
-                    display=default_variable_display)
+                    display=default_variable_display,
+                )
 
         # Delete all data_values in dataset
 
         print("Deleting all data_values...")
 
-        db.execute("""
+        db.execute(
+            """
             DELETE FROM data_values
             WHERE variableId IN %s
-        """, [tuple(db_variable_id_by_name.values())])
+        """,
+            [tuple(db_variable_id_by_name.values())],
+        )
 
         # Insert new data_values
 
         print("Inserting new data_values...")
 
         df_data_values = df.melt(
-            id_vars=id_names,
-            value_vars=variable_names,
-            var_name='variable',
-            value_name='value'
-        ).dropna(how='any')
+            id_vars=id_names, value_vars=variable_names, var_name="variable", value_name="value"
+        ).dropna(how="any")
 
         for df_chunk in chunk_df(df_data_values, 50000):
             data_values = [
-                (row['value'], int(row['Year']), db_entity_id_by_name[row['Country']], db_variable_id_by_name[row['variable']])
+                (
+                    row["value"],
+                    int(row["Year"]),
+                    db_entity_id_by_name[row["Country"]],
+                    db_variable_id_by_name[row["variable"]],
+                )
                 for _, row in df_chunk.iterrows()
             ]
-            db.upsert_many("""
+            db.upsert_many(
+                """
                 INSERT INTO
                     data_values (value, year, entityId, variableId)
                 VALUES
                     (%s, %s, %s, %s)
-            """, data_values)
+            """,
+                data_values,
+            )
 
         # Update dataset dataUpdatedAt time & dataUpdatedBy
 
-        db.execute("""
+        db.execute(
+            """
             UPDATE datasets
             SET
                 dataEditedAt = NOW(),
                 dataEditedByUserId = %s
             WHERE id = %s
-        """, [USER_ID, db_dataset_id])
+        """,
+            [USER_ID, db_dataset_id],
+        )
 
         # Update source name ("last updated at")
 
-        db.execute("""
+        db.execute(
+            """
             UPDATE sources
             SET name = %s
             WHERE id = %s
-        """, [source_name, db_source_id])
+        """,
+            [source_name, db_source_id],
+        )
 
         # Update chart versions to trigger rebake
 
-        db.execute("""
+        db.execute(
+            """
             UPDATE charts
             SET config = JSON_SET(config, "$.version", config->"$.version" + 1)
             WHERE id IN (
@@ -208,21 +241,29 @@ def import_dataset(dataset_name, namespace, csv_path, default_variable_display, 
                 JOIN variables ON variables.id = chart_dimensions.variableId
                 WHERE variables.datasetId = %s
             )
-        """, [db_dataset_id])
+        """,
+            [db_dataset_id],
+        )
 
         # Enqueue deploy
 
         if DEPLOY_QUEUE_PATH:
-            with open(DEPLOY_QUEUE_PATH, 'a') as f:
-                f.write(json.dumps({
-                    'message': f"Automated dataset update: {dataset_name}",
-                    'timeISOString': datetime.now().isoformat()
-                }) + "\n")
+            raise Exception("this code path is no longer used -- see cowidev version")
+            with open(DEPLOY_QUEUE_PATH, "a") as f:
+                f.write(
+                    json.dumps(
+                        {
+                            "message": f"Automated dataset update: {dataset_name}",
+                            "timeISOString": datetime.now().isoformat(),
+                        }
+                    )
+                    + "\n"
+                )
 
     print("Database update successful.")
 
     if slack_notifications:
         send_success(
-            channel='corona-data-updates' if not os.getenv('IS_DEV') else 'bot-testing',
-            title=f'Updated Grapher dataset: {dataset_name}'
+            channel="corona-data-updates" if not os.getenv("IS_DEV") else "bot-testing",
+            title=f"Updated Grapher dataset: {dataset_name}",
         )


### PR DESCRIPTION
Previously, it was assumed that the live server for Grapher was the same server that the covid scripts were running on. In that scenario, deploying just means writing to a file.

This change means that the live server can be on a different machine, and it will ssh to that machine and set the deploy queue path.
